### PR TITLE
Improved error message for expected type

### DIFF
--- a/source/piston_window/functions.rs
+++ b/source/piston_window/functions.rs
@@ -1,0 +1,27 @@
+fn print_function(f) {
+    print(f.name)
+    print("(")
+    n := len(f.arguments)
+    for i := 0; i < n; i += 1 {
+        print(f.arguments[i].name)
+        if f.arguments[i].lifetime != none() {
+            print(": '" + unwrap(f.arguments[i].lifetime))
+        }
+        if (i + 1) < n {
+            print(", ")
+        }
+    }
+    print(")")
+    if f.returns {
+        print(" ->")
+    }
+    println("")
+}
+
+fn print_functions(functions) {
+    n := len(functions)
+    for i := 0; i < n; i += 1 {
+        if functions[i].type != "external" { continue }
+        print_function(functions[i])
+    }
+}

--- a/source/piston_window/loader.rs
+++ b/source/piston_window/loader.rs
@@ -3,6 +3,16 @@ fn main() {
     println("Press A and D to steer.")
     println("Reset with R.")
     println("You can modify \"source/piston_window/snake.rs\" while running.")
+
+    {
+        println("External functions:")
+        println("===================")
+        functions := unwrap(load("source/piston_window/functions.rs"))
+        list := functions()
+        call(functions, "print_functions", [list])
+        println("===================")
+    }
+
     source := "source/piston_window/snake.rs"
     m := unwrap(load(source))
 

--- a/source/piston_window/snake.rs
+++ b/source/piston_window/snake.rs
@@ -31,7 +31,7 @@ fn render(settings, data) {
     }
     for i := 0; i < n; i += 1 {
         pos := data.snake_body[i]
-        draw(color: [.2, .2, 0, 1], rect: [
+        draw(color: [.2, .2, 0, 1], rectangle: [
             pos[0] - 0.5 * size, pos[1] - 0.5 * size, size, size])
     }
     if n > 0 {

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,8 +1,9 @@
-fn main() {
-    println(foo())
-}
 
-fn foo() -> {
-    x := [1, 2, 3]
-    return clone(pop(x))
+fn main() {
+    println("1")
+    sleep(1)
+    println("2")
+    sleep(2)
+    println("3")
+    sleep(3)
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -211,6 +211,11 @@ impl Runtime {
         }
     }
 
+    pub fn expected(&self, var: &Variable, ty: &str) -> String {
+        let found_ty = self.typeof_var(var);
+        format!("{}\nExpected `{}`, found `{}`", self.stack_trace(), ty, found_ty)
+    }
+
     #[inline(always)]
     pub fn resolve<'a>(&'a self, var: &'a Variable) -> &'a Variable {
         resolve(&self.stack, var)


### PR DESCRIPTION
- Added `draw_color_rectangle` to piston_window example
- Improved expected type error messages in piston_window example
- Print out available external functions in piston_window example
- Renamed `draw_color_rect` to `draw_color_rectangle`
- Fixed bug in “sleep” intrinsic
- Use static string for “There is no value on the stack”
- Improved expected type error in intrinsics
- Added `Runtime::expected`