### PR TITLE
Mutability check on function arguments

### DIFF
--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -11,7 +11,7 @@ _seps: "(){}[],.:;=<>*+-/%^?"
 
 0 fn = ["fn" .w! .."("!:"name" ?w "(" args ")" ?w ?"->":"returns" ?w block:"block"]
 1 args = .s?.([?w "," ?w] arg:"arg")
-2 arg = [?"mut" ?w .._seps!:"name" ?[?w ":" ?w "'" ?w .._seps!:"lifetime"]]
+2 arg = [?"mut":"mut" ?w .._seps!:"name" ?[?w ":" ?w "'" ?w .._seps!:"lifetime"]]
 // Support both multi-line expressions and single line.
 3 block = ["{" ?w {.l([?w expr:"expr" ?w]) [?w expr:"expr"]} ?w "}"]
 4 expr = [{
@@ -39,23 +39,26 @@ _seps: "(){}[],.:;=<>*+-/%^?"
     item:"item"
 } ?[?w "?":"try"]]
 // Interprets "return" as variable, does not expect loops or assignment.
-5 arg_expr = [?"mut" ?w {
-    object:"object"
-    array:"array"
-    array_fill:"array_fill"
-    if:"if"
-    block:"block"
-    compare:"compare"
-    add:"add"
-    ["(" ?w expr ?w ")"]
-    unop:"unop"
-    text
-    call:"call"
-    named_call:"named_call"
-    num
-    bool
-    item:"item"
-} ?[?w "?":"try"]]
+5 arg_expr = {
+    ["mut":"mut" ?w item:"item"]
+    [{
+        object:"object"
+        array:"array"
+        array_fill:"array_fill"
+        if:"if"
+        block:"block"
+        compare:"compare"
+        add:"add"
+        ["(" ?w expr ?w ")"]
+        unop:"unop"
+        text
+        call:"call"
+        named_call:"named_call"
+        num
+        bool
+        item:"item"
+    } ?[?w "?":"try"]]
+}
 6 lexpr = [{
     object:"object"
     array:"array"

--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -11,7 +11,7 @@ _seps: "(){}[],.:;=<>*+-/%^?"
 
 0 fn = ["fn" .w! .."("!:"name" ?w "(" args ")" ?w ?"->":"returns" ?w block:"block"]
 1 args = .s?.([?w "," ?w] arg:"arg")
-2 arg = [.._seps!:"name" ?[?w ":" ?w "'" ?w .._seps!:"lifetime"]]
+2 arg = [?"mut" ?w .._seps!:"name" ?[?w ":" ?w "'" ?w .._seps!:"lifetime"]]
 // Support both multi-line expressions and single line.
 3 block = ["{" ?w {.l([?w expr:"expr" ?w]) [?w expr:"expr"]} ?w "}"]
 4 expr = [{
@@ -39,7 +39,7 @@ _seps: "(){}[],.:;=<>*+-/%^?"
     item:"item"
 } ?[?w "?":"try"]]
 // Interprets "return" as variable, does not expect loops or assignment.
-5 arg_expr = [{
+5 arg_expr = [?"mut" ?w {
     object:"object"
     array:"array"
     array_fill:"array_fill"

--- a/source/lifetime_6.rs
+++ b/source/lifetime_6.rs
@@ -2,12 +2,12 @@ fn bar(b) -> {
     return clone(b)
 }
 
-fn foo(a, b) {
+fn foo(mut a, b) {
     a[0] = bar(b)
 }
 
 fn main() {
     a := [0]
     b := 3
-    foo(a, b)
+    foo(mut a, b)
 }

--- a/source/piston_window/loader.rs
+++ b/source/piston_window/loader.rs
@@ -29,9 +29,9 @@ fn main() {
             dt := unwrap(update_dt())
             // Slow down when window is unfocused.
             dt *= if data.focused { settings.focus_speed } else { settings.unfocus_speed }
-            call(m, "update", [data, settings, dt])
+            call(m, "update(mut,_,_)", [data, settings, dt])
         }
-        event(loader: loader, source: source, settings: settings, module: m)
+        event(loader: mut loader, source: source, settings: mut settings, module: mut m)
         key := press_keyboard_key()
         if key != none() {
             key := unwrap(key)
@@ -99,7 +99,7 @@ fn should_reload(loader) -> {
         && ((loader.last_reload + loader.reload_interval) < loader.time)
 }
 
-fn event_loader_source_settings_module(loader, source, settings, m) {
+fn event_loader_source_settings_module(mut loader, source, mut settings, mut m) {
     if update() {
         dt := unwrap(update_dt())
         loader.time += dt

--- a/source/piston_window/snake.rs
+++ b/source/piston_window/snake.rs
@@ -45,7 +45,7 @@ fn render(settings, data) {
     }
 }
 
-fn update(data, settings, dt) {
+fn update(mut data, settings, dt) {
     if data.pressing_left {
         data.snake_angle -= settings.turn_speed * dt
     }

--- a/source/prop.rs
+++ b/source/prop.rs
@@ -1,4 +1,4 @@
-fn reset(pos) {
+fn reset(mut pos) {
     pos.x = 0
     pos.y = 0
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -3,15 +3,12 @@ fn foo(mut a, b) {
     a[0] = clone(b)
 }
 
-fn foo(mut x) {
-    x = 3
+fn bar(a, b) {
+    foo(mut a, b)
 }
 
 fn main() {
     a := [4]
     b := 5
-    foo(mut a, b)
-    println(a)
-    foo(mut b)
-    println(b)
+    bar(a, b)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,5 +1,11 @@
 
+fn foo(mut a, b) {
+    a[0] = clone(b)
+}
+
 fn main() {
-    x := to_string({x: 0, y: 1})
-    println(x)
+    a := [4]
+    b := 5
+    foo(mut a, b)
+    println(a)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,11 +1,15 @@
 
-fn foo(mut a, b) {
+fn foo_one_two(mut a, b) {
+    a[0] = clone(b)
+}
+
+fn foo_one_two(a, b) {
     a[0] = clone(b)
 }
 
 fn main() {
     a := [4]
     b := 5
-    foo(mut a, b)
+    foo(one: mut a, two: b)
     println(a)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,14 +1,16 @@
 
-fn foo(mut a, b) {
-    a[0] = clone(b)
+fn foo(mut list) {
+    push(mut list, 3)
 }
 
-fn bar(a, b) {
-    foo(mut a, b)
+fn bar(mut list: 'return) -> {
+    return pop(mut list)
 }
 
 fn main() {
-    a := [4]
-    b := 5
-    bar(a, b)
+    list := []
+    foo(mut list)
+    println(list)
+    bar(mut list)
+    println(list)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -3,8 +3,8 @@ fn foo(mut a, b) {
     a[0] = clone(b)
 }
 
-fn foo(x, y) {
-    println(x)
+fn foo(mut x) {
+    x = 3
 }
 
 fn main() {

--- a/source/test.rs
+++ b/source/test.rs
@@ -3,8 +3,8 @@ fn foo(mut a, b) {
     a[0] = clone(b)
 }
 
-fn foo(mut x) {
-    x = 3
+fn foo(x, y) {
+    println(x)
 }
 
 fn main() {

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,15 +1,17 @@
 
-fn foo_one_two(mut a, b) {
+fn foo(mut a, b) {
     a[0] = clone(b)
 }
 
-fn foo_one_two(a, b) {
-    a[0] = clone(b)
+fn foo(mut x) {
+    x = 3
 }
 
 fn main() {
     a := [4]
     b := 5
-    foo(one: mut a, two: b)
+    foo(mut a, b)
     println(a)
+    foo(mut b)
+    println(b)
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -83,8 +83,11 @@ impl Function {
         if mutable_args {
             let mut name_plus_args = String::from(&**name);
             name_plus_args.push('(');
+            let mut first = true;
             for arg in &args {
-                name_plus_args.push_str(if arg.mutable { "mut," } else { "_," });
+                if !first { name_plus_args.push(','); }
+                name_plus_args.push_str(if arg.mutable { "mut" } else { "_" });
+                first = false;
             }
             name_plus_args.push(')');
             name = Arc::new(name_plus_args);
@@ -906,8 +909,11 @@ impl Call {
         if mutable.iter().any(|&arg| arg) {
             let mut name_plus_args = String::from(&**name);
             name_plus_args.push('(');
+            let mut first = true;
             for &arg in &mutable {
-                name_plus_args.push_str(if arg { "mut," } else { "_," });
+                if !first { name_plus_args.push(','); }
+                name_plus_args.push_str(if arg { "mut" } else { "_" });
+                first = false;
             }
             name_plus_args.push(')');
             name = Arc::new(name_plus_args);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -77,8 +77,18 @@ impl Function {
             }
         }
 
-        let name = try!(name.ok_or(()));
+        let mut name = try!(name.ok_or(()));
         let block = try!(block.ok_or(()));
+        let mutable_args = args.iter().any(|arg| arg.mutable);
+        if mutable_args {
+            let mut name_plus_args = String::from(&**name);
+            name_plus_args.push('(');
+            for arg in &args {
+                name_plus_args.push_str(if arg.mutable { "mut," } else { "_," });
+            }
+            name_plus_args.push(')');
+            name = Arc::new(name_plus_args);
+        }
         Ok((convert.subtract(start), Function {
             name: name,
             file: file,
@@ -95,6 +105,7 @@ pub struct Arg {
     pub name: Arc<String>,
     pub lifetime: Option<Arc<String>>,
     pub source_range: Range,
+    pub mutable: bool,
 }
 
 impl Arg {
@@ -107,10 +118,14 @@ impl Arg {
 
         let mut name: Option<Arc<String>> = None;
         let mut lifetime: Option<Arc<String>> = None;
+        let mut mutable = false;
         loop {
             if let Ok(range) = convert.end_node(node) {
                 convert.update(range);
                 break;
+            } else if let Ok((range, val)) = convert.meta_bool("mut") {
+                convert.update(range);
+                mutable = val;
             } else if let Ok((range, val)) = convert.meta_string("name") {
                 convert.update(range);
                 name = Some(val);
@@ -129,6 +144,7 @@ impl Arg {
             name: name,
             lifetime: lifetime,
             source_range: convert.source(start).unwrap(),
+            mutable: mutable,
         }))
     }
 }
@@ -209,6 +225,9 @@ impl Expression {
             if let Ok(range) = convert.end_node(node) {
                 convert.update(range);
                 break;
+            } else if let Ok((range, _)) = convert.meta_bool("mut") {
+                // Ignore `mut` since it is handled by lifetime checker.
+                convert.update(range);
             } else if let Ok((range, val)) = Object::from_meta_data(
                     convert, ignored) {
                 convert.update(range);
@@ -856,6 +875,7 @@ impl Call {
 
         let mut name: Option<Arc<String>> = None;
         let mut args = vec![];
+        let mut mutable: Vec<bool> = vec![];
         loop {
             if let Ok(range) = convert.end_node(node) {
                 convert.update(range);
@@ -865,6 +885,14 @@ impl Call {
                 name = Some(val);
             } else if let Ok((range, val)) = Expression::from_meta_data(
                 "call_arg", convert, ignored) {
+                let mut peek = convert.clone();
+                mutable.push(match peek.start_node("call_arg") {
+                    Ok(r) => {
+                        peek.update(r);
+                        peek.meta_bool("mut").is_ok()
+                    }
+                    _ => unreachable!()
+                });
                 convert.update(range);
                 args.push(val);
             } else {
@@ -874,7 +902,16 @@ impl Call {
             }
         }
 
-        let name = try!(name.ok_or(()));
+        let mut name = try!(name.ok_or(()));
+        if mutable.iter().any(|&arg| arg) {
+            let mut name_plus_args = String::from(&**name);
+            name_plus_args.push('(');
+            for &arg in &mutable {
+                name_plus_args.push_str(if arg { "mut," } else { "_," });
+            }
+            name_plus_args.push(')');
+            name = Arc::new(name_plus_args);
+        }
         Ok((convert.subtract(start), Call {
             name: name,
             args: args,

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -59,11 +59,11 @@ pub fn standard(f: &mut HashMap<Arc<String>, PreludeFunction>) {
         lts: vec![Lt::Default],
         returns: true
     });
-    f.insert(Arc::new("push".into()), PreludeFunction {
+    f.insert(Arc::new("push(mut,_)".into()), PreludeFunction {
         lts: vec![Lt::Default, Lt::Arg(0)],
         returns: false
     });
-    f.insert(Arc::new("pop".into()), PreludeFunction {
+    f.insert(Arc::new("pop(mut)".into()), PreludeFunction {
         lts: vec![Lt::Return],
         returns: true
     });
@@ -411,7 +411,7 @@ pub fn call_standard(
             rt.pop_fn(call.name.clone());
             Expect::Something
         }
-        "push" => {
+        "push(mut,_)" => {
             rt.push_fn(call.name.clone(), None, st + 1, lc);
             let item = rt.stack.pop().expect(TINVOTS);
             let v = rt.stack.pop().expect(TINVOTS);
@@ -436,7 +436,7 @@ pub fn call_standard(
             rt.pop_fn(call.name.clone());
             Expect::Nothing
         }
-        "pop" => {
+        "pop(mut)" => {
             rt.push_fn(call.name.clone(), None, st + 1, lc);
             let arr = rt.stack.pop().expect(TINVOTS);
             let mut v: Option<Variable> = None;

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -999,7 +999,8 @@ pub fn call_standard(
             rt.pop_fn(call.name.clone());
             Expect::Something
         }
-        _ => panic!("Unknown function `{}`", call.name)
+        _ => return Err(module.error(call.source_range,
+            &format!("{}\nUnknown function `{}`", rt.stack_trace(), call.name)))
     };
     Ok((expect, Flow::Continue))
 }

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -115,11 +115,14 @@ pub fn check(
         if mutable_args {
             let mut name_plus_args = String::from(&***nodes[i].name.as_ref().unwrap());
             name_plus_args.push('(');
+            let mut first = true;
             for &arg in nodes[i].children.iter()
                 .filter(|&&n| match nodes[n].kind {
                     Kind::Arg | Kind::CallArg => true, _ => false
                 }) {
-                name_plus_args.push_str(if nodes[arg].mutable { "mut," } else { "_," });
+                if !first { name_plus_args.push(','); }
+                name_plus_args.push_str(if nodes[arg].mutable { "mut" } else { "_" });
+                first = false;
             }
             name_plus_args.push(')');
             nodes[i].name = Some(Arc::new(name_plus_args));

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -480,6 +480,19 @@ pub fn check(
         }
     }
 
+    // Check that mutable locals are not immutable arguments.
+    for &(_, i) in &mutated_locals {
+        if let Some(decl) = nodes[i].declaration {
+            if nodes[decl].kind == Kind::Arg {
+                if !nodes[decl].mutable {
+                    return Err(nodes[i].source.wrap(
+                        format!("Requires `mut {}`", nodes[i].name.as_ref().unwrap())
+                    ));
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Added a mutability check on function arguments. All function arguments are immutable by default.

- Mutability information is appended to function name, e.g. `foo(mut a, b)` is `foo(mut,_)`
- Pure functions have no mutability information, e.g. `foo(a, b)` is just `foo`
- Lifetime checker prevents assigning to immutable arguments
- Lifetime checker prevents calling a function taking a mutable parameter with an immutable argument
- Added function suggestions when declaration of a function can not be found
- Added function suggestions when expected different number of arguments to a function

Example:

```rust
fn foo(mut a, b) {
    a[0] = clone(b)
}

fn bar(a, b) {
    foo(mut a, b)
}

fn main() {
    a := [4]
    b := 5
    bar(a, b)
}
```

```
 --- ERROR --- 
In `source/test.rs`:
Requires `mut a`
7,13:     foo(mut a, b)
7,13:             ^
```

It is allowed to declare multiple functions with same name using different mutability patterns.

Example:

```rust
fn reset_x(pos) -> {
    return [0, clone(pos[1])]
}

fn reset_x(mut pos) {
    pos[0] = 0
}

fn main() {
    pos := [1, 2]
    println(pos)
    println(reset_x(pos))
    reset_x(mut pos)
    println(pos)
}
```