### PR TITLE
Lifetime and assignment fixes

### DIFF
--- a/source/accessor.rs
+++ b/source/accessor.rs
@@ -10,8 +10,8 @@ fn title(window: 'return) -> {
     return window.title
 }
 
-fn title(mut window, val: 'window) {
-    window.title = val
+fn title(mut window, val) {
+    window.title = clone(val)
 }
 
 fn main() {

--- a/source/named_call.rs
+++ b/source/named_call.rs
@@ -1,7 +1,7 @@
 fn up_to(n) -> {
     x := []
     for i := 0; i < n; i += 1 {
-        push(mut x, clone(i))
+        push(mut x, i)
     }
     return clone(x)
 }

--- a/source/piston_window/loader.rs
+++ b/source/piston_window/loader.rs
@@ -80,7 +80,7 @@ fn init_snake_body_parts_size(parts, size) -> {
     // end := [(parts - 1) * size, (parts - 1) * size]
     end := [0, 0]
     for i := 0; i < parts; i += 1 {
-        push(body, [end[0] - i * size, end[1] - i * size])
+        push(mut body, [end[0] - i * size, end[1] - i * size])
     }
     return clone(body)
 }
@@ -104,7 +104,7 @@ fn event_loader_source_settings_module(mut loader, source, mut settings, mut m) 
         dt := unwrap(update_dt())
         loader.time += dt
         if should_reload(loader) {
-            loader.last_reload = loader.time
+            loader.last_reload = clone(loader.time)
             new_m := load(source)
             if is_err(new_m) {
                 loader.got_error = true

--- a/source/piston_window/snake.rs
+++ b/source/piston_window/snake.rs
@@ -74,5 +74,5 @@ fn update(mut data, settings, dt) {
             pos[1] + dir[1] * speed
         ]
     }
-    data.snake_body = data.next_snake_body
+    data.snake_body = clone(data.next_snake_body)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,4 +1,3 @@
-/*
 fn foo(mut a, b: 'a) {
     a = b
 }
@@ -8,16 +7,57 @@ fn main() {
     a := [[]]
     foo(mut a, b)
     println(a)
-    debug()
+    // debug()
 
     push(mut a, b)
+    // b = [3]
+    println(a)
+}
+
+/*
+fn main() {
+    b := {x: {}}
+    a := {x: 6}
+    foo(mut a, b)
+    println(a)
+
+    a.x = b
     println(a)
 }
 */
 
+/*
+fn main() {
+    b := some({x: {}})
+    a := some({x: 6})
+    foo(mut a, b)
+    println(a)
+    debug()
+
+    b = none()
+    println(a)
+}
+*/
+
+/*
+fn main() {
+    b := ok({x: {}})
+    a := ok({x: 6})
+    foo(mut a, b)
+    println(a)
+    debug()
+
+    b = err("no")
+    println(a)
+}
+*/
+
+/*
 fn main() {
     a := [5]
     b := [6]
     b = a
-    debug()
+    b[0] = 3
+    println(a)
 }
+*/

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,63 +1,6 @@
-fn foo(mut a, b: 'a) {
-    a = b
-}
-
 fn main() {
-    b := [[5]]
-    a := [[]]
-    foo(mut a, b)
-    println(a)
-    // debug()
-
+    a := []
+    b := {cool: true}
     push(mut a, b)
-    // b = [3]
     println(a)
 }
-
-/*
-fn main() {
-    b := {x: {}}
-    a := {x: 6}
-    foo(mut a, b)
-    println(a)
-
-    a.x = b
-    println(a)
-}
-*/
-
-/*
-fn main() {
-    b := some({x: {}})
-    a := some({x: 6})
-    foo(mut a, b)
-    println(a)
-    debug()
-
-    b = none()
-    println(a)
-}
-*/
-
-/*
-fn main() {
-    b := ok({x: {}})
-    a := ok({x: 6})
-    foo(mut a, b)
-    println(a)
-    debug()
-
-    b = err("no")
-    println(a)
-}
-*/
-
-/*
-fn main() {
-    a := [5]
-    b := [6]
-    b = a
-    b[0] = 3
-    println(a)
-}
-*/

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,5 +1,23 @@
+/*
+fn foo(mut a, b: 'a) {
+    a = b
+}
 
 fn main() {
-    m := unwrap(load("source/bench/n_body.rs"))
-    call(m, "main", [])
+    b := [[5]]
+    a := [[]]
+    foo(mut a, b)
+    println(a)
+    debug()
+
+    push(mut a, b)
+    println(a)
+}
+*/
+
+fn main() {
+    a := [5]
+    b := [6]
+    b = a
+    debug()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,45 +187,49 @@ mod tests {
     use super::run;
     use self::test::Bencher;
 
+    fn run_bench(source: &str) {
+        run(source).unwrap_or_else(|err| panic!("{}", err));
+    }
+
     #[bench]
     fn bench_add(b: &mut Bencher) {
         b.iter(||
-            run("source/bench/add.rs")
+            run_bench("source/bench/add.rs")
         );
     }
 
     #[bench]
     fn bench_add_n(b: &mut Bencher) {
         b.iter(||
-            run("source/bench/add_n.rs")
+            run_bench("source/bench/add_n.rs")
         );
     }
 
     #[bench]
     fn bench_main(b: &mut Bencher) {
         b.iter(||
-            run("source/bench/main.rs")
+            run_bench("source/bench/main.rs")
         );
     }
 
     #[bench]
     fn bench_array(b: &mut Bencher) {
         b.iter(||
-            run("source/bench/array.rs")
+            run_bench("source/bench/array.rs")
         );
     }
 
     #[bench]
     fn bench_object(b: &mut Bencher) {
         b.iter(||
-            run("source/bench/object.rs")
+            run_bench("source/bench/object.rs")
         );
     }
 
     #[bench]
     fn bench_call(b: &mut Bencher) {
         b.iter(||
-            run("source/bench/call.rs")
+            run_bench("source/bench/call.rs")
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -877,7 +877,7 @@ impl Runtime {
                                 }
                             }
                         }
-                        &Variable::Object(ref obj) => {
+                        &Variable::Object(ref b) => {
                             unsafe {
                                 match *r {
                                     Variable::Object(ref mut n) => {
@@ -885,9 +885,9 @@ impl Runtime {
                                             // Check address to avoid unsafe
                                             // reading and writing to same memory.
                                             let n_addr = n as *const _ as usize;
-                                            let obj_addr = obj as *const _ as usize;
-                                            if n_addr != obj_addr {
-                                                *r = b.clone()
+                                            let b_addr = b as *const _ as usize;
+                                            if n_addr != b_addr {
+                                                *r = Variable::Object(b.clone())
                                             }
                                             // *n = obj.clone()
                                         } else {
@@ -896,7 +896,7 @@ impl Runtime {
                                     }
                                     Variable::Return => {
                                         if let Set = op {
-                                            *r = Variable::Object(obj.clone())
+                                            *r = Variable::Object(b.clone())
                                         } else {
                                             return Err(module.error(
                                                 left.source_range(),
@@ -911,7 +911,7 @@ impl Runtime {
                                 }
                             }
                         }
-                        &Variable::Array(ref arr) => {
+                        &Variable::Array(ref b) => {
                             unsafe {
                                 match *r {
                                     Variable::Array(ref mut n) => {
@@ -919,9 +919,9 @@ impl Runtime {
                                             // Check address to avoid unsafe
                                             // reading and writing to same memory.
                                             let n_addr = n as *const _ as usize;
-                                            let arr_addr = arr as *const _ as usize;
-                                            if n_addr != arr_addr {
-                                                *r = b.clone()
+                                            let b_addr = b as *const _ as usize;
+                                            if n_addr != b_addr {
+                                                *r = Variable::Array(b.clone())
                                             }
                                             // *n = arr.clone();
                                         } else {
@@ -930,7 +930,7 @@ impl Runtime {
                                     }
                                     Variable::Return => {
                                         if let Set = op {
-                                            *r = Variable::Array(arr.clone())
+                                            *r = Variable::Array(b.clone())
                                         } else {
                                             return Err(module.error(
                                                 left.source_range(),
@@ -945,7 +945,7 @@ impl Runtime {
                                 }
                             }
                         }
-                        &Variable::Option(ref opt) => {
+                        &Variable::Option(ref b) => {
                             unsafe {
                                 match *r {
                                     Variable::Option(ref mut n) => {
@@ -953,9 +953,9 @@ impl Runtime {
                                             // Check address to avoid unsafe
                                             // reading and writing to same memory.
                                             let n_addr = n as *const _ as usize;
-                                            let obj_addr = opt as *const _ as usize;
-                                            if n_addr != obj_addr {
-                                                *r = b.clone()
+                                            let b_addr = b as *const _ as usize;
+                                            if n_addr != b_addr {
+                                                *r = Variable::Option(b.clone())
                                             }
                                         } else {
                                             unimplemented!()
@@ -963,7 +963,7 @@ impl Runtime {
                                     }
                                     Variable::Return => {
                                         if let Set = op {
-                                            *r = Variable::Option(opt.clone())
+                                            *r = Variable::Option(b.clone())
                                         } else {
                                             return Err(module.error(
                                                 left.source_range(),
@@ -978,7 +978,7 @@ impl Runtime {
                                 }
                             }
                         }
-                        &Variable::Result(ref res) => {
+                        &Variable::Result(ref b) => {
                             unsafe {
                                 match *r {
                                     Variable::Result(ref mut n) => {
@@ -986,9 +986,9 @@ impl Runtime {
                                             // Check address to avoid unsafe
                                             // reading and writing to same memory.
                                             let n_addr = n as *const _ as usize;
-                                            let obj_addr = res as *const _ as usize;
-                                            if n_addr != obj_addr {
-                                                *r = b.clone()
+                                            let b_addr = b as *const _ as usize;
+                                            if n_addr != b_addr {
+                                                *r = Variable::Result(b.clone())
                                             }
                                         } else {
                                             unimplemented!()
@@ -996,7 +996,7 @@ impl Runtime {
                                     }
                                     Variable::Return => {
                                         if let Set = op {
-                                            *r = Variable::Result(res.clone())
+                                            *r = Variable::Result(b.clone())
                                         } else {
                                             return Err(module.error(
                                                 left.source_range(),
@@ -1011,7 +1011,7 @@ impl Runtime {
                                 }
                             }
                         }
-                        &Variable::RustObject(ref robj) => {
+                        &Variable::RustObject(ref b) => {
                             unsafe {
                                 match *r {
                                     Variable::RustObject(ref mut n) => {
@@ -1019,9 +1019,9 @@ impl Runtime {
                                             // Check address to avoid unsafe
                                             // reading and writing to same memory.
                                             let n_addr = n as *const _ as usize;
-                                            let obj_addr = robj as *const _ as usize;
-                                            if n_addr != obj_addr {
-                                                *r = b.clone()
+                                            let b_addr = b as *const _ as usize;
+                                            if n_addr != b_addr {
+                                                *r = Variable::RustObject(b.clone())
                                             }
                                         } else {
                                             unimplemented!()
@@ -1029,7 +1029,7 @@ impl Runtime {
                                     }
                                     Variable::Return => {
                                         if let Set = op {
-                                            *r = Variable::RustObject(robj.clone())
+                                            *r = Variable::RustObject(b.clone())
                                         } else {
                                             return Err(module.error(
                                                 left.source_range(),


### PR DESCRIPTION
This PR fixes various problems with the lifetime checker, and makes changes to the behavior of assignment.

### Use shallow clone of right value on `=`

Without this rule, the following example prints out infinite `[[[[[[[...` and overflows the stack:

```rust
fn main() {
    b := [[]]
    a := [b]
    a[0][0] = b
    println(b)
}
```

This happens because `a[0][0]` inspects `b[0]` and assigns it a reference to `b`, leading to an infinite cycle. By doing a shallow clone of `b`, it prints out `[[[]]]`.

Also prevents variables from getting entangled when mutated.

### Require reference to variable on calling arguments with lifetime

The old `push` is renamed to `push_ref`, and a new `push` intrinsic was added that uses a deep clone.

Previously, it was allowed to do things like this:

```rust
fn foo(mut a, b: 'a) {
    push_ref(mut a, b)
}

fn main() {
    b := [3]
    a := []
    foo(mut a, [b])
    println(a)
}
```

This leads to a panic with the message "index out of bounds". The problem is that `[b]` is pushed as a reference in `a`, then the stack rolls back, freeing `[b]` before printing `a`.

The new lifetime rule requires reference to a variable not just for `'return`, but for all arguments with a lifetime. This gives an error:

```
 --- ERROR --- 
In `source/test.rs`:
Requires reference to variable
8,16:     foo(mut a, [b])
8,16:                ^
```

Fixed code:

```rust
fn foo(mut a, b) {
    push(mut a, b)
}

fn main() {
    b := [3]
    a := []
    foo(mut a, [b])
    println(a)
}
```

The fixed code uses deep clone on `push` because there is no way to use `push_ref` to pass the lifetime checker.

The alternative to rename `push` was to add a new `push_clone`, but this was not easy to use since you expect things like `push(mut a, "hi")` to work.

### Report error on lifetime with equal ordering

Without this rule, the following example prints out infinite `[[[[[[[...` and overflows the stack:

```rust
fn main() {
    a := [[]]
    a[0] = [a]
    println(a)
}
```

This happens because `a` inspects itself and then inserts an array with a reference to itself, leading to an infinite cycle.

The new rule makes the lifetime checker report an error:

```
 --- ERROR --- 
In `source/test.rs`:
`a` does not live long enough
4,12:     a[0] = [a]
4,12:            ^
```