### PR TITLE
Added sift filter loop

### DIFF
--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -89,10 +89,11 @@ _seps: "(){}[],.:;=<>*+-/%^?"
             text call:"call" named_call:"named_call"
             num bool item:"item"}
 
-40 short_loops = {sum:"sum" min:"min" max:"max"}
+40 short_loops = {sum:"sum" min:"min" max:"max" sift:"sift"}
 41 sum = [label {"sum" "∑"} short_body]
 42 min = [label "min" short_body]
 42 max = [label "max" short_body]
+43 sift = [label "sift" short_body]
 
 101 + = [?w {"+":"+" "||":"+"} ?w]
 102 - = [?w "-":"-" ?w]

--- a/source/bench/primes.rs
+++ b/source/bench/primes.rs
@@ -1,0 +1,14 @@
+fn main() {
+    a := primes(10000)
+}
+
+fn primes(n) -> {
+    return 'prime: sift i n-2 {
+        p := i + 2
+        for j sqrt(p)-2 {
+            o := j + 2
+            if (p % o) == 0 { continue 'prime }
+        }
+        clone(p)
+    }
+}

--- a/source/bench/primes_trad.rs
+++ b/source/bench/primes_trad.rs
@@ -1,0 +1,16 @@
+fn main() {
+    a := primes_trad(10000)
+}
+
+fn primes_trad(n) -> {
+    x := []
+    'prime: for i n-2 {
+        p := i + 2
+        for j sqrt(p)-2 {
+            o := j + 2
+            if (p % o) == 0 { continue 'prime }
+        }
+        push(mut x, p)
+    }
+    return clone(x)
+}

--- a/source/syntax/lifetime_8.rs
+++ b/source/syntax/lifetime_8.rs
@@ -1,0 +1,5 @@
+fn main() {
+    a := sum i 3 { i }
+    b := min i 3 { i }
+    c := max i 3 { i }
+}

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,19 +1,28 @@
 fn main() {
     println(primes(100))
+    println(primes_trad(100))
 }
 
 fn primes(n) -> {
-    x := 'prime: sift i n-2 {
+    return clone('prime: sift i n-2 {
         p := i + 2
         for j sqrt(p)-2 {
             o := j + 2
             if (p % o) == 0 { continue 'prime }
         }
         clone(p)
-    }
-    return clone(x)
+    })
 }
 
-fn foo() {
-    a := sum i 3 { i }
+fn primes_trad(n) -> {
+    x := []
+    'prime: for i n-2 {
+        p := i + 2
+        for j sqrt(p)-2 {
+            o := j + 2
+            if (p % o) == 0 { continue 'prime }
+        }
+        push(mut x, p)
+    }
+    return clone(x)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,7 +1,19 @@
 fn main() {
-    println(foo(3))
+    println(primes(100))
 }
 
-fn foo(x) -> {
-    return 3 == x
+fn primes(n) -> {
+    x := 'prime: sift i n-2 {
+        p := i + 2
+        for j sqrt(p)-2 {
+            o := j + 2
+            if (p % o) == 0 { continue 'prime }
+        }
+        clone(p)
+    }
+    return clone(x)
+}
+
+fn foo() {
+    a := sum i 3 { i }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -210,6 +210,7 @@ pub enum Expression {
     Sum(Box<ForN>),
     Min(Box<ForN>),
     Max(Box<ForN>),
+    Sift(Box<ForN>),
     If(Box<If>),
     Compare(Box<Compare>),
     UnOp(Box<UnOpExpression>),
@@ -325,6 +326,10 @@ impl Expression {
                     "max", convert, ignored) {
                 convert.update(range);
                 result = Some(Expression::Max(Box::new(val)));
+            } else if let Ok((range, val)) = ForN::from_meta_data(
+                    "sift", convert, ignored) {
+                convert.update(range);
+                result = Some(Expression::Sift(Box::new(val)));
             } else if let Ok((range, val)) = Loop::from_meta_data(
                     convert, ignored) {
                 convert.update(range);
@@ -379,6 +384,7 @@ impl Expression {
             Sum(ref for_n_expr) => for_n_expr.source_range,
             Min(ref for_n_expr) => for_n_expr.source_range,
             Max(ref for_n_expr) => for_n_expr.source_range,
+            Sift(ref for_n_expr) => for_n_expr.source_range,
             If(ref if_expr) => if_expr.source_range,
             Compare(ref comp) => comp.source_range,
             UnOp(ref unop) => unop.source_range,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,78 +195,66 @@ mod tests {
 
     #[bench]
     fn bench_add(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/add.rs")
-        );
+        b.iter(|| run_bench("source/bench/add.rs"));
     }
 
     #[bench]
     fn bench_add_n(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/add_n.rs")
-        );
+        b.iter(|| run_bench("source/bench/add_n.rs"));
     }
 
     #[bench]
     fn bench_sum(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/sum.rs")
-        );
+        b.iter(|| run_bench("source/bench/sum.rs"));
     }
 
     #[bench]
     fn bench_main(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/main.rs")
-        );
+        b.iter(|| run_bench("source/bench/main.rs"));
     }
 
     #[bench]
     fn bench_array(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/array.rs")
-        );
+        b.iter(|| run_bench("source/bench/array.rs"));
     }
 
     #[bench]
     fn bench_object(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/object.rs")
-        );
+        b.iter(|| run_bench("source/bench/object.rs"));
     }
 
     #[bench]
     fn bench_call(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/call.rs")
-        );
+        b.iter(|| run_bench("source/bench/call.rs"));
     }
 
     #[bench]
     fn bench_n_body(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/n_body.rs")
-        );
+        b.iter(|| run_bench("source/bench/n_body.rs"));
     }
 
     #[bench]
     fn bench_len(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/len.rs")
-        );
+        b.iter(|| run_bench("source/bench/len.rs"));
     }
 
     #[bench]
     fn bench_min_fn(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/min_fn.rs")
-        );
+        b.iter(|| run_bench("source/bench/min_fn.rs"));
     }
 
     #[bench]
     fn bench_min(b: &mut Bencher) {
-        b.iter(||
-            run_bench("source/bench/min.rs")
-        );
+        b.iter(|| run_bench("source/bench/min.rs"));
+    }
+
+    #[bench]
+    fn bench_primes(b: &mut Bencher) {
+        b.iter(|| run_bench("source/bench/primes.rs"));
+    }
+
+    #[bench]
+    fn bench_primes_trad(b: &mut Bencher) {
+        b.iter(|| run_bench("source/bench/primes_trad.rs"));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2103,8 +2103,8 @@ impl Runtime {
             match try!(self.block(&for_n_expr.block, module)) {
                 (_, Flow::Return) => { return Ok(Flow::Return); }
                 (Expect::Something, Flow::Continue) => {
-                    res.push(self.stack.last()
-                        .expect("There is no value on the stack").clone());
+                    res.push(self.stack.pop()
+                        .expect("There is no value on the stack"));
                 }
                 (Expect::Nothing, Flow::Continue) => {
                     return Err(module.error(for_n_expr.block.source_range,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2095,7 +2095,6 @@ impl Runtime {
                 &Variable::F64(val) => {
                     if val < end {}
                     else { break }
-                    val
                 }
                 x => return Err(module.error(for_n_expr.source_range,
                                 &self.expected(x, "number")))

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2108,7 +2108,7 @@ impl Runtime {
                 }
                 (Expect::Nothing, Flow::Continue) => {
                     return Err(module.error(for_n_expr.block.source_range,
-                                "Expected `number`"))
+                                "Expected variable"))
                 }
                 (_, Flow::Break(x)) => {
                     match x {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -10,6 +10,14 @@ pub fn test_src(source: &str) {
     });
 }
 
+pub fn test_fail_src(source: &str) {
+    let mut module = Module::new();
+    match load(source, &mut module) {
+        Ok(_) => panic!("`{}` should fail", source),
+        Err(_) => {}
+    };
+}
+
 pub fn debug_src(source: &str) {
     let mut module = Module::new();
     load(source, &mut module).unwrap_or_else(|err| {
@@ -39,7 +47,13 @@ fn test_syntax() {
     test_src("source/syntax/assign_if.rs");
     test_src("source/syntax/new_pos.rs");
     test_src("source/syntax/lifetime.rs");
+    test_fail_src("source/syntax/lifetime_2.rs");
+    test_fail_src("source/syntax/lifetime_3.rs");
+    test_fail_src("source/syntax/lifetime_4.rs");
+    test_fail_src("source/syntax/lifetime_5.rs");
     test_src("source/syntax/lifetime_6.rs");
+    test_src("source/syntax/lifetime_7.rs");
+    test_src("source/syntax/lifetime_8.rs");
     test_src("source/syntax/insert.rs");
     test_src("source/syntax/named_call.rs");
     test_src("source/syntax/max_min.rs");


### PR DESCRIPTION
See https://github.com/PistonDevelopers/dyon/issues/119

This PR adds a Sift filter loop, similar to the ∑ loop.

### Example

Generate a list of primes up to a number `n`:

```rust
fn primes(n) -> {
    return 'prime: sift i n-2 {
        p := i + 2
        for j sqrt(p)-2 {
            o := j + 2
            if (p % o) == 0 { continue 'prime }
        }
        clone(p)
    }
}
```

This is equal to:

```rust
fn primes_trad(n) -> {
    x := []
    'prime: for i n-2 {
        p := i + 2
        for j sqrt(p)-2 {
            o := j + 2
            if (p % o) == 0 { continue 'prime }
        }
        push(mut x, p)
    }
    return clone(x)
}
```