### PR TITLE
Added `for i [start, end) { ... }`

### DIFF
--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -81,7 +81,8 @@ _seps: "(){}[],.:;=<>*+-/%^?"
 27 compare_op = {"==":"==" "!=":"!=" "<=":"<=" "<":"<" ">=":">=" ">":">"}
 
 30 label = ?["'" .._seps!:"label" ?w ":" ?w]
-31 short_body = [.w! .._seps!:"name" ?w expr:"end" ?w block:"block"]
+31 short_body = [.w! .._seps!:"name" ?w {["[" ?w expr:"start" , expr:"end" ?w ")"]
+                 expr:"end"} ?w block:"block"]
 32 try = ?[?w "?":"try"]
 33 , = [?w "," ?w]
 34 arr = {array:"array" array_fill:"array_fill"}

--- a/source/bench/n_body.rs
+++ b/source/bench/n_body.rs
@@ -78,8 +78,8 @@ fn pairwise_diffs_bodies_diff(bodies, mut diff) {
     n := len(bodies)
     k := 0
     for i n {
-        for j n-i-1 {
-            diff[k] = vec3_sub(bodies[i].pos, bodies[j+i+1].pos)
+        for j [i+1, n) {
+            diff[k] = vec3_sub(bodies[i].pos, bodies[j].pos)
             k += 1
         }
     }
@@ -102,8 +102,7 @@ fn update_velocities_bodies_dt_diff_mag(mut bodies, dt, mut diff, mut mag) {
     n := len(bodies)
     k := 0
     for i n {
-        for j n-i-1 {
-            j := j+i+1
+        for j [i+1, n) {
             diff := diff[k]
             mag := mag[k]
             bodies[i].vel = vec3_sub(bodies[i].vel,
@@ -136,8 +135,7 @@ fn energy(bodies) -> {
     for i n {
         e += vec3_squared_norm(bodies[i].vel) * bodies[i].mass / 2.0
         m := 0
-        for j n-i-1 {
-            j := j+i+1
+        for j [i+1, n) {
             m += bodies[j].mass /
                  vec3_norm(vec3_sub(bodies[i].pos, bodies[j].pos))
         }

--- a/source/bench/primes.rs
+++ b/source/bench/primes.rs
@@ -3,12 +3,8 @@ fn main() {
 }
 
 fn primes(n) -> {
-    return 'prime: sift i n-2 {
-        p := i + 2
-        for j sqrt(p)-2 {
-            o := j + 2
-            if (p % o) == 0 { continue 'prime }
-        }
-        clone(p)
+    return 'prime: sift i [2, n) {
+        for j [2, sqrt(i)) { if (i % j) == 0 { continue 'prime } }
+        clone(i)
     }
 }

--- a/source/bench/primes_trad.rs
+++ b/source/bench/primes_trad.rs
@@ -4,13 +4,9 @@ fn main() {
 
 fn primes_trad(n) -> {
     x := []
-    'prime: for i n-2 {
-        p := i + 2
-        for j sqrt(p)-2 {
-            o := j + 2
-            if (p % o) == 0 { continue 'prime }
-        }
-        push(mut x, p)
+    'prime: for i [2, n) {
+        for j [2, sqrt(i)) { if (i % j) == 0 { continue 'prime } }
+        push(mut x, i)
     }
     return clone(x)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,28 +1,9 @@
 fn main() {
-    println(primes(100))
-    println(primes_trad(100))
-}
-
-fn primes(n) -> {
-    return clone('prime: sift i n-2 {
-        p := i + 2
-        for j sqrt(p)-2 {
-            o := j + 2
-            if (p % o) == 0 { continue 'prime }
-        }
-        clone(p)
-    })
-}
-
-fn primes_trad(n) -> {
-    x := []
-    'prime: for i n-2 {
-        p := i + 2
-        for j sqrt(p)-2 {
-            o := j + 2
-            if (p % o) == 0 { continue 'prime }
-        }
-        push(mut x, p)
+    for i [2, 4) {
+        println(i)
     }
-    return clone(x)
+    println(min i [2, 4) { i })
+    println(max i [2, 4) { i })
+    println(sum i [2, 4) { i })
+    println(sift i [2, 8) { clone(i) })
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1272,6 +1272,7 @@ impl For {
 #[derive(Debug, Clone)]
 pub struct ForN {
     pub name: Arc<String>,
+    pub start: Option<Expression>,
     pub end: Expression,
     pub block: Block,
     pub label: Option<Arc<String>>,
@@ -1289,7 +1290,8 @@ impl ForN {
         convert.update(start_range);
 
         let mut name: Option<Arc<String>> = None;
-        let mut end: Option<Expression> = None;
+        let mut start_expr: Option<Expression> = None;
+        let mut end_expr: Option<Expression> = None;
         let mut block: Option<Block> = None;
         let mut label: Option<Arc<String>> = None;
         loop {
@@ -1307,9 +1309,13 @@ impl ForN {
                 convert.update(range);
                 name = Some(val);
             } else if let Ok((range, val)) = Expression::from_meta_data(
+                "start", convert, ignored) {
+                convert.update(range);
+                start_expr = Some(val);
+            } else if let Ok((range, val)) = Expression::from_meta_data(
                 "end", convert, ignored) {
                 convert.update(range);
-                end = Some(val);
+                end_expr = Some(val);
             } else {
                 let range = convert.ignore();
                 convert.update(range);
@@ -1318,11 +1324,12 @@ impl ForN {
         }
 
         let name = try!(name.ok_or(()));
-        let end = try!(end.ok_or(()));
+        let end_expr = try!(end_expr.ok_or(()));
         let block = try!(block.ok_or(()));
         Ok((convert.subtract(start), ForN {
             name: name,
-            end: end,
+            start: start_expr,
+            end: end_expr,
             block: block,
             label: label,
             source_range: convert.source(start).unwrap(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1663,9 +1663,28 @@ impl Runtime {
     ) -> Result<Flow, String> {
         let prev_st = self.stack.len();
         let prev_lc = self.local_stack.len();
+
+        let start = if let Some(ref start) = for_n_expr.start {
+            // Evaluate start such that it's on the stack.
+            match try!(self.expression(start, Side::Right, module)) {
+                (_, Flow::Return) => { return Ok(Flow::Return); }
+                (Expect::Something, Flow::Continue) => {}
+                _ => return Err(module.error(for_n_expr.end.source_range(),
+                    &format!("{}\nExpected number from for start",
+                        self.stack_trace())))
+            };
+            let start = self.stack.pop().expect("There is no value on the stack");
+            let start = match self.resolve(&start) {
+                &Variable::F64(val) => val,
+                x => return Err(module.error(for_n_expr.end.source_range(),
+                                &self.expected(x, "number")))
+            };
+            start
+        } else { 0.0 };
+
         // Initialize counter.
         self.local_stack.push((for_n_expr.name.clone(), self.stack.len()));
-        self.stack.push(Variable::F64(0.0));
+        self.stack.push(Variable::F64(start));
         // Evaluate end such that it's on the stack.
         match try!(self.expression(&for_n_expr.end, Side::Right, module)) {
             (_, Flow::Return) => { return Ok(Flow::Return); }
@@ -1749,9 +1768,28 @@ impl Runtime {
         let prev_st = self.stack.len();
         let prev_lc = self.local_stack.len();
         let mut sum = 0.0;
+
+        let start = if let Some(ref start) = for_n_expr.start {
+            // Evaluate start such that it's on the stack.
+            match try!(self.expression(start, Side::Right, module)) {
+                (_, Flow::Return) => { return Ok(Flow::Return); }
+                (Expect::Something, Flow::Continue) => {}
+                _ => return Err(module.error(for_n_expr.end.source_range(),
+                    &format!("{}\nExpected number from for start",
+                        self.stack_trace())))
+            };
+            let start = self.stack.pop().expect("There is no value on the stack");
+            let start = match self.resolve(&start) {
+                &Variable::F64(val) => val,
+                x => return Err(module.error(for_n_expr.end.source_range(),
+                                &self.expected(x, "number")))
+            };
+            start
+        } else { 0.0 };
+
         // Initialize counter.
         self.local_stack.push((for_n_expr.name.clone(), self.stack.len()));
-        self.stack.push(Variable::F64(0.0));
+        self.stack.push(Variable::F64(start));
         // Evaluate end such that it's on the stack.
         match try!(self.expression(&for_n_expr.end, Side::Right, module)) {
             (_, Flow::Return) => { return Ok(Flow::Return); }
@@ -1781,7 +1819,8 @@ impl Runtime {
             match try!(self.block(&for_n_expr.block, module)) {
                 (_, Flow::Return) => { return Ok(Flow::Return); }
                 (Expect::Something, Flow::Continue) => {
-                    match self.stack.last().expect("There is no value on the stack") {
+                    match self.resolve(self.stack.last()
+                              .expect("There is no value on the stack")) {
                         &Variable::F64(val) => sum += val,
                         x => return Err(module.error(for_n_expr.block.source_range,
                                 &self.expected(x, "number")))
@@ -1845,10 +1884,29 @@ impl Runtime {
     ) -> Result<Flow, String> {
         let prev_st = self.stack.len();
         let prev_lc = self.local_stack.len();
+
+        let start = if let Some(ref start) = for_n_expr.start {
+            // Evaluate start such that it's on the stack.
+            match try!(self.expression(start, Side::Right, module)) {
+                (_, Flow::Return) => { return Ok(Flow::Return); }
+                (Expect::Something, Flow::Continue) => {}
+                _ => return Err(module.error(for_n_expr.end.source_range(),
+                    &format!("{}\nExpected number from for start",
+                        self.stack_trace())))
+            };
+            let start = self.stack.pop().expect("There is no value on the stack");
+            let start = match self.resolve(&start) {
+                &Variable::F64(val) => val,
+                x => return Err(module.error(for_n_expr.end.source_range(),
+                                &self.expected(x, "number")))
+            };
+            start
+        } else { 0.0 };
+
         let mut min: Option<(f64, f64)> = None;
         // Initialize counter.
         self.local_stack.push((for_n_expr.name.clone(), self.stack.len()));
-        self.stack.push(Variable::F64(0.0));
+        self.stack.push(Variable::F64(start));
         // Evaluate end such that it's on the stack.
         match try!(self.expression(&for_n_expr.end, Side::Right, module)) {
             (_, Flow::Return) => { return Ok(Flow::Return); }
@@ -1879,7 +1937,8 @@ impl Runtime {
             match try!(self.block(&for_n_expr.block, module)) {
                 (_, Flow::Return) => { return Ok(Flow::Return); }
                 (Expect::Something, Flow::Continue) => {
-                    match self.stack.last().expect("There is no value on the stack") {
+                    match self.resolve(self.stack.last()
+                              .expect("There is no value on the stack")) {
                         &Variable::F64(val) => {
                             if let Some((ref mut min_arg, ref mut min_val)) = min {
                                 if *min_val > val {
@@ -1957,10 +2016,29 @@ impl Runtime {
     ) -> Result<Flow, String> {
         let prev_st = self.stack.len();
         let prev_lc = self.local_stack.len();
+
+        let start = if let Some(ref start) = for_n_expr.start {
+            // Evaluate start such that it's on the stack.
+            match try!(self.expression(start, Side::Right, module)) {
+                (_, Flow::Return) => { return Ok(Flow::Return); }
+                (Expect::Something, Flow::Continue) => {}
+                _ => return Err(module.error(for_n_expr.end.source_range(),
+                    &format!("{}\nExpected number from for start",
+                        self.stack_trace())))
+            };
+            let start = self.stack.pop().expect("There is no value on the stack");
+            let start = match self.resolve(&start) {
+                &Variable::F64(val) => val,
+                x => return Err(module.error(for_n_expr.end.source_range(),
+                                &self.expected(x, "number")))
+            };
+            start
+        } else { 0.0 };
+
         let mut max: Option<(f64, f64)> = None;
         // Initialize counter.
         self.local_stack.push((for_n_expr.name.clone(), self.stack.len()));
-        self.stack.push(Variable::F64(0.0));
+        self.stack.push(Variable::F64(start));
         // Evaluate end such that it's on the stack.
         match try!(self.expression(&for_n_expr.end, Side::Right, module)) {
             (_, Flow::Return) => { return Ok(Flow::Return); }
@@ -1991,7 +2069,8 @@ impl Runtime {
             match try!(self.block(&for_n_expr.block, module)) {
                 (_, Flow::Return) => { return Ok(Flow::Return); }
                 (Expect::Something, Flow::Continue) => {
-                    match self.stack.last().expect("There is no value on the stack") {
+                    match self.resolve(self.stack.last()
+                              .expect("There is no value on the stack")) {
                         &Variable::F64(val) => {
                             if let Some((ref mut max_arg, ref mut max_val)) = max {
                                 if *max_val < val {
@@ -2070,9 +2149,29 @@ impl Runtime {
         let prev_st = self.stack.len();
         let prev_lc = self.local_stack.len();
         let mut res: Vec<Variable> = vec![];
+
+        let start = if let Some(ref start) = for_n_expr.start {
+            // Evaluate start such that it's on the stack.
+            match try!(self.expression(start, Side::Right, module)) {
+                (_, Flow::Return) => { return Ok(Flow::Return); }
+                (Expect::Something, Flow::Continue) => {}
+                _ => return Err(module.error(for_n_expr.end.source_range(),
+                    &format!("{}\nExpected number from for start",
+                        self.stack_trace())))
+            };
+            let start = self.stack.pop().expect("There is no value on the stack");
+            let start = match self.resolve(&start) {
+                &Variable::F64(val) => val,
+                x => return Err(module.error(for_n_expr.end.source_range(),
+                                &self.expected(x, "number")))
+            };
+            start
+        } else { 0.0 };
+
         // Initialize counter.
         self.local_stack.push((for_n_expr.name.clone(), self.stack.len()));
-        self.stack.push(Variable::F64(0.0));
+        self.stack.push(Variable::F64(start));
+
         // Evaluate end such that it's on the stack.
         match try!(self.expression(&for_n_expr.end, Side::Right, module)) {
             (_, Flow::Return) => { return Ok(Flow::Return); }
@@ -2103,7 +2202,7 @@ impl Runtime {
                 (_, Flow::Return) => { return Ok(Flow::Return); }
                 (Expect::Something, Flow::Continue) => {
                     res.push(self.stack.pop()
-                        .expect("There is no value on the stack"));
+                       .expect("There is no value on the stack"));
                 }
                 (Expect::Nothing, Flow::Continue) => {
                     return Err(module.error(for_n_expr.block.source_range,


### PR DESCRIPTION
- Added `[start, end)` syntax
- Added `ForN::start`
- Updated prime benchmarks
- Moved `deep_clone` to `Variable::deep_clone`
- Check lifetime on call arguments to make sure they outlive the call,
using the call as fake local