### PR TITLE
Added 4D vectors

### DIFF
--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -1,4 +1,4 @@
-_seps: "(){}[],.:;=<>*·+-/%^?|&∧∨!¬∑∃∀"
+_seps: "(){}[],.:;=<>*·+-/%^?|&∧∨!¬∑∃∀\n"
 
 200 multi_line_comment = ["/*" ..."*/"? .r?({
     [!"*/" "*" ..."*/"?] [multi_line_comment ..."*/"?] ["/" ..."*/"?]
@@ -107,7 +107,13 @@ _seps: "(){}[],.:;=<>*·+-/%^?|&∧∨!¬∑∃∀"
 
 101 + = [?w {"+":"+" "||":"+" "∨":"+" "or":"+"} ?w]
 102 - = [?w "-":"-" ?w]
-103 * = [?w {"*.":"*." "·":"*." "*":"*" "&&":"*" "∧":"*" "and":"*"} ?w]
+// Allow whitespace before multiplication sign, but no new line.
+// This prevents `x` on a new line from being interpreted as multiplication sign.
+103 * = [.r?({" " "\t" "\r"}) {
+    "*.":"*." "·":"*."
+    "x":"x" "⨯":"x"
+    "*":"*" "&&":"*" "∧":"*" "and":"*"
+} ?w]
 104 / = [?w "/":"/" ?w]
 105 % = [?w "%":"%" ?w]
 107 pow = [lexpr:"base" ?w "^" ?w lexpr:"exp"]

--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -1,4 +1,4 @@
-_seps: "(){}[],.:;=<>*+-/%^?"
+_seps: "(){}[],.:;=<>*·+-/%^?|&∧∨!¬∑∃∀"
 
 200 multi_line_comment = ["/*" ..."*/"? .r?({
     [!"*/" "*" ..."*/"?] [multi_line_comment ..."*/"?] ["/" ..."*/"?]
@@ -58,9 +58,13 @@ _seps: "(){}[],.:;=<>*+-/%^?"
 9 array_fill = ["[" ?w expr:"fill" ?w ";" ?w expr:"n" ?w "]"]
 10 key_value = [.._seps!:"key" ?w ":" ?w expr:"val"]
 11 num = .$_:"num"
+12 vec4 = ["(" ?w expr:"x" , expr:"y" ?[, expr:"z" ?[, expr:"w"]] ?w ")"]
 12 text = .t?:"text"
 13 bool = {"true":"bool" "false":!"bool"}
-14 unop = [{"!":"!" "¬":"!" "-":"-"} ?w lexpr:"expr"]
+14 unop = {
+    [{"!":"!" "¬":"!" "-":"-"} ?w lexpr:"expr"]
+    ["|":"norm" ?w expr:"expr" ?w "|"]
+}
 15 item = [.._seps!:"name" ?[?w "?":"try_item"] .r?([{
            [?w "[" ?w {.t?:"id" .$_:"id" expr:"id"} ?w "]"]
            [?w "." ?w .._seps!:"id"]} ?[?w "?":"try_id"]])]
@@ -89,7 +93,7 @@ _seps: "(){}[],.:;=<>*+-/%^?"
 32 try = ?[?w "?":"try"]
 33 , = [?w "," ?w]
 34 arr = {array:"array" array_fill:"array_fill"}
-35 items = {["(" ?w expr ?w ")"] unop:"unop"
+35 items = {vec4:"vec4" ["(" ?w expr ?w ")"] unop:"unop"
             text call:"call" named_call:"named_call"
             num bool item:"item"}
 
@@ -103,7 +107,7 @@ _seps: "(){}[],.:;=<>*+-/%^?"
 
 101 + = [?w {"+":"+" "||":"+" "∨":"+" "or":"+"} ?w]
 102 - = [?w "-":"-" ?w]
-103 * = [?w {"*":"*" "&&":"*" "∧":"*" "and":"*"} ?w]
+103 * = [?w {"*.":"*." "·":"*." "*":"*" "&&":"*" "∧":"*" "and":"*"} ?w]
 104 / = [?w "/":"/" ?w]
 105 % = [?w "%":"%" ?w]
 107 pow = [lexpr:"base" ?w "^" ?w lexpr:"exp"]

--- a/source/bench/n_body.rs
+++ b/source/bench/n_body.rs
@@ -4,58 +4,50 @@ year() = 365.24
 n_bodies() = 5
 n_pairs() = n_bodies() * (n_bodies() - 1) / 2
 
-vec3(x, y, z) = [clone(x), clone(y), clone(z)]
-vec3_zero() = [0, 0, 0]
-vec3_norm(self) = sqrt(vec3_squared_norm(self))
-vec3_squared_norm(self) = self[0] * self[0] + self[1] * self[1] + self[2] * self[2]
-vec3_add(a, b) = [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
-vec3_sub(a, b) = [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
-vec3_mul(a, b) = [a[0] * b, a[1] * b, a[2] * b]
-
 fn bodies() -> {
     return [
         // Sun
         {
-            pos: vec3(0, 0, 0),
-            vel: vec3(0, 0, 0),
+            pos: (0, 0, 0),
+            vel: (0, 0, 0),
             mass: solar_mass()
         },
         // Jupiter
         {
-            pos: vec3(4.84143144246472090e+00,
+            pos: (4.84143144246472090e+00,
                         -1.16032004402742839e+00,
                         -1.03622044471123109e-01),
-            vel: vec3(1.66007664274403694e-03 * year(),
+            vel: (1.66007664274403694e-03 * year(),
                         7.69901118419740425e-03 * year(),
                         -6.90460016972063023e-05 * year()),
             mass: 9.54791938424326609e-04 * solar_mass(),
         },
         // Saturn
         {
-            pos: vec3(8.34336671824457987e+00,
+            pos: (8.34336671824457987e+00,
                         4.12479856412430479e+00,
                         -4.03523417114321381e-01),
-            vel: vec3(-2.76742510726862411e-03 * year(),
+            vel: (-2.76742510726862411e-03 * year(),
                         4.99852801234917238e-03 * year(),
                         2.30417297573763929e-05 * year()),
             mass: 2.85885980666130812e-04 * solar_mass(),
         },
         // Uranus
         {
-            pos: vec3(1.28943695621391310e+01,
+            pos: (1.28943695621391310e+01,
                         -1.51111514016986312e+01,
                         -2.23307578892655734e-01),
-            vel: vec3(2.96460137564761618e-03 * year(),
+            vel: (2.96460137564761618e-03 * year(),
                         2.37847173959480950e-03 * year(),
                         -2.96589568540237556e-05 * year()),
             mass: 4.36624404335156298e-05 * solar_mass(),
         },
         // Neptune
         {
-            pos: vec3(1.53796971148509165e+01,
+            pos: (1.53796971148509165e+01,
                         -2.59193146099879641e+01,
                         1.79258772950371181e-01),
-            vel: vec3(2.68067772490389322e-03 * year(),
+            vel: (2.68067772490389322e-03 * year(),
                         1.62824170038242295e-03 * year(),
                         -9.51592254519715870e-05 * year()),
             mass: 5.15138902046611451e-05 * solar_mass(),
@@ -69,7 +61,7 @@ fn pairwise_diffs_bodies_diff(bodies, mut diff) {
     k := 0
     for i n {
         for j [i+1, n) {
-            diff[k] = vec3_sub(bodies[i].pos, bodies[j].pos)
+            diff[k] = bodies[i].pos - bodies[j].pos
             k += 1
         }
     }
@@ -78,8 +70,7 @@ fn pairwise_diffs_bodies_diff(bodies, mut diff) {
 /// Computes the magnitude of the force between each pair of planets.
 fn magnitudes_diff_dt_mag(diff, dt, mut mag) {
     for i len(diff) {
-        d2 := vec3_squared_norm(diff[i])
-        mag[i] = dt / (d2 * sqrt(d2))
+        mag[i] = dt / |diff[i]|^3
     }
 }
 
@@ -93,12 +84,9 @@ fn update_velocities_bodies_dt_diff_mag(mut bodies, dt, mut diff, mut mag) {
     k := 0
     for i n {
         for j [i+1, n) {
-            diff := diff[k]
-            mag := mag[k]
-            bodies[i].vel = vec3_sub(bodies[i].vel,
-                            vec3_mul(diff, bodies[j].mass * mag))
-            bodies[j].vel = vec3_add(bodies[j].vel,
-                            vec3_mul(diff, bodies[i].mass * mag))
+            diff := diff[k] * mag[k]
+            bodies[i].vel -= diff * bodies[j].mass
+            bodies[j].vel += diff * bodies[i].mass
             k += 1
         }
     }
@@ -114,39 +102,37 @@ fn update_velocities_bodies_dt_diff_mag(mut bodies, dt, mut diff, mut mag) {
 fn advance_bodies_dt_diff_mag(mut bodies, dt, mut diff, mut mag) {
     update_velocities(bodies: mut bodies, dt: dt, diff: mut diff, mag: mut mag)
     for i len(bodies) {
-        bodies[i].pos = vec3_add(bodies[i].pos, vec3_mul(bodies[i].vel, dt))
+        bodies[i].pos += bodies[i].vel * dt
     }
 }
 
 /// Computes the total energy of the solar system.
 fn energy(bodies) -> {
-    e := 0.0
     n := len(bodies)
-    for i n {
-        e += vec3_squared_norm(bodies[i].vel) * bodies[i].mass / 2.0
+    return ∑ i n {
+        e := bodies[i].vel · bodies[i].vel * bodies[i].mass / 2.0
         m := 0
         for j [i+1, n) {
-            m += bodies[j].mass /
-                 vec3_norm(vec3_sub(bodies[i].pos, bodies[j].pos))
+            m += bodies[j].mass / |bodies[i].pos - bodies[j].pos|
         }
         e -= bodies[i].mass * m
+        e
     }
-    return clone(e)
 }
 
 /// Offsets the sun's velocity to make the overall momentum of the system zero.
 fn offset_momentum(mut bodies) {
-    p := vec3_zero()
+    p := (0, 0, 0)
     for i len(bodies) {
-        p = vec3_add(p, vec3_mul(bodies[i].vel, bodies[i].mass))
+        p += bodies[i].vel * bodies[i].mass
     }
-    bodies[0].vel = vec3_mul(p, (-1.0 / bodies[0].mass))
+    bodies[0].vel = p * (-1.0 / bodies[0].mass)
 }
 
 fn main() {
     n := 1000
     bodies := bodies()
-    diff := [vec3_zero(); n_pairs()]
+    diff := [(0, 0, 0); n_pairs()]
     mag := [0; n_pairs()]
 
     offset_momentum(mut bodies)

--- a/source/syntax/vec4.rs
+++ b/source/syntax/vec4.rs
@@ -1,0 +1,13 @@
+fn main() {
+    a := (0, 0, 1)
+    b := (1, 0, 0)
+    c := a ⨯ b
+    d := a · b
+    println(c)
+    println(d)
+
+    c := a x b
+    d := a *. b
+    println(c)
+    println(d)
+}

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,20 +1,6 @@
 fn main() {
-    println(¬ ∃ i 3 { i == 7 })
-    // println(any(3))
-    println(∀ i 3 { (i ¬= 5) ∨ (i < 2) })
-    // println(all(3))
-}
-
-fn any(n) -> {
-    return = false
-    for i n {
-        if i == 2 { return true }
-    }
-}
-
-fn all(n) -> {
-    return = true
-    for i n {
-        if i != 5 { return false }
-    }
+    a := (1, 2, 3, 4)
+    b := 3
+    c := 3 / a
+    println(c)
 }

--- a/source/test.rs
+++ b/source/test.rs
@@ -1,6 +1,6 @@
 fn main() {
-    a := (1, 2, 3, 4)
-    b := 3
-    c := 3 / a
-    println(c)
+    v := (1, 0, 0)
+    u := (0, 1, 0)
+    x := v x u
+    println(x)
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -219,6 +219,7 @@ pub enum Expression {
     Assign(Box<Assign>),
     Text(Text),
     Number(Number),
+    Vec4(Vec4),
     Bool(Bool),
     For(Box<For>),
     ForN(Box<ForN>),
@@ -305,6 +306,10 @@ impl Expression {
                     num: val,
                     source_range: convert.source(start).unwrap(),
                 }));
+            } else if let Ok((range, val)) = Vec4::from_meta_data(
+                    convert, ignored) {
+                convert.update(range);
+                result = Some(Expression::Vec4(val));
             } else if let Ok((range, val)) = convert.meta_bool("bool") {
                 convert.update(range);
                 result = Some(Expression::Bool(Bool {
@@ -403,6 +408,7 @@ impl Expression {
             Assign(ref assign) => assign.source_range,
             Text(ref text) => text.source_range,
             Number(ref num) => num.source_range,
+            Vec4(ref vec4) => vec4.source_range,
             Bool(ref b) => b.source_range,
             For(ref for_expr) => for_expr.source_range,
             ForN(ref for_n_expr) => for_n_expr.source_range,
@@ -672,6 +678,9 @@ impl Mul {
                 convert, ignored) {
                 convert.update(range);
                 items.push(val);
+            } else if let Ok((range, _)) = convert.meta_bool("*.") {
+                convert.update(range);
+                ops.push(BinOp::Dot);
             } else if let Ok((range, _)) = convert.meta_bool("*") {
                 convert.update(range);
                 ops.push(BinOp::Mul);
@@ -799,6 +808,7 @@ pub enum BinOp {
     Add,
     Sub,
     Mul,
+    Dot,
     Div,
     Rem,
     Pow
@@ -810,6 +820,7 @@ impl BinOp {
             BinOp::Add => "+",
             BinOp::Sub => "-",
             BinOp::Mul => "*",
+            BinOp::Dot => "*.",
             BinOp::Div => "/",
             BinOp::Rem => "%",
             BinOp::Pow => "^",
@@ -828,7 +839,8 @@ impl BinOp {
 #[derive(Debug, Copy, Clone)]
 pub enum UnOp {
     Not,
-    Neg
+    Neg,
+    Norm,
 }
 
 #[derive(Debug, Clone)]
@@ -1091,6 +1103,9 @@ impl UnOpExpression {
             } else if let Ok((range, _)) = convert.meta_bool("-") {
                 convert.update(range);
                 unop = Some(UnOp::Neg);
+            } else if let Ok((range, _)) = convert.meta_bool("norm") {
+                convert.update(range);
+                unop = Some(UnOp::Norm);
             } else if let Ok((range, val)) = Expression::from_meta_data(
                 "expr", convert, ignored) {
                 convert.update(range);
@@ -1212,6 +1227,68 @@ pub enum AssignOp {
 pub struct Number {
     pub num: f64,
     pub source_range: Range,
+}
+
+#[derive(Debug, Clone)]
+pub struct Vec4 {
+    pub args: Vec<Expression>,
+    pub source_range: Range,
+}
+
+impl Vec4 {
+    pub fn from_meta_data(
+        mut convert: Convert,
+        ignored: &mut Vec<Range>)
+    -> Result<(Range, Vec4), ()> {
+        let start = convert.clone();
+        let node = "vec4";
+        let start_range = try!(convert.start_node(node));
+        convert.update(start_range);
+
+        let mut x: Option<Expression> = None;
+        let mut y: Option<Expression> = None;
+        let mut z: Option<Expression> = None;
+        let mut w: Option<Expression> = None;
+        loop {
+            if let Ok(range) = convert.end_node(node) {
+                convert.update(range);
+                break;
+            } else if let Ok((range, val)) = Expression::from_meta_data(
+                "x", convert, ignored) {
+                convert.update(range);
+                x = Some(val);
+            } else if let Ok((range, val)) = Expression::from_meta_data(
+                "y", convert, ignored) {
+                convert.update(range);
+                y = Some(val);
+            } else if let Ok((range, val)) = Expression::from_meta_data(
+                "z", convert, ignored) {
+                convert.update(range);
+                z = Some(val);
+            } else if let Ok((range, val)) = Expression::from_meta_data(
+                "w", convert, ignored) {
+                convert.update(range);
+                w = Some(val);
+            } else {
+                let range = convert.ignore();
+                convert.update(range);
+                ignored.push(range);
+            }
+        }
+
+        let x = try!(x.ok_or(()));
+        let y = try!(y.ok_or(()));
+        let z = z.unwrap_or(Expression::Number(
+            Number { num: 0.0, source_range: Range::empty(0) }
+        ));
+        let w = w.unwrap_or(Expression::Number(
+            Number { num: 0.0, source_range: Range::empty(0) }
+        ));
+        Ok((convert.subtract(start), Vec4 {
+            args: vec![x, y, z, w],
+            source_range: convert.source(start).unwrap(),
+        }))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -681,6 +681,9 @@ impl Mul {
             } else if let Ok((range, _)) = convert.meta_bool("*.") {
                 convert.update(range);
                 ops.push(BinOp::Dot);
+            } else if let Ok((range, _)) = convert.meta_bool("x") {
+                convert.update(range);
+                ops.push(BinOp::Cross);
             } else if let Ok((range, _)) = convert.meta_bool("*") {
                 convert.update(range);
                 ops.push(BinOp::Mul);
@@ -809,6 +812,7 @@ pub enum BinOp {
     Sub,
     Mul,
     Dot,
+    Cross,
     Div,
     Rem,
     Pow
@@ -821,6 +825,7 @@ impl BinOp {
             BinOp::Sub => "-",
             BinOp::Mul => "*",
             BinOp::Dot => "*.",
+            BinOp::Cross => "x",
             BinOp::Div => "/",
             BinOp::Rem => "%",
             BinOp::Pow => "^",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub enum Variable {
     Return,
     Bool(bool),
     F64(f64),
+    Vec4([f32; 4]),
     Text(Arc<String>),
     Array(Array),
     Object(Object),
@@ -51,6 +52,7 @@ impl Variable {
 
         match *self {
             F64(_) => self.clone(),
+            Vec4(_) => self.clone(),
             Return => self.clone(),
             Bool(_) => self.clone(),
             Text(_) => self.clone(),

--- a/src/lifetime.rs
+++ b/src/lifetime.rs
@@ -768,7 +768,8 @@ impl Node {
     ) -> Option<Lifetime> {
         match self.kind {
             Kind::Add | Kind::Mul | Kind::Pow | Kind::Compare
-            | Kind::Sum | Kind::Min | Kind::Max | Kind::Any | Kind::All => {
+            | Kind::Sum | Kind::Min | Kind::Max | Kind::Any | Kind::All
+            | Kind::Vec4 => {
                 if self.children.len() > 1 {
                     return None;
                 }
@@ -832,6 +833,7 @@ impl Node {
                 (_, Kind::Max) => {}
                 (_, Kind::Any) => {}
                 (_, Kind::All) => {}
+                (_, Kind::Vec4) => {}
                 (_, Kind::Start) => { continue }
                 (_, Kind::End) => { continue }
                 (_, Kind::Assign) => {}
@@ -1027,6 +1029,11 @@ pub enum Kind {
     Break,
     Continue,
     UnOp,
+    Vec4,
+    X,
+    Y,
+    Z,
+    W,
 }
 
 impl Kind {
@@ -1081,6 +1088,11 @@ impl Kind {
             "break" => Kind::Break,
             "continue" => Kind::Continue,
             "unop" => Kind::UnOp,
+            "vec4" => Kind::Vec4,
+            "x" => Kind::X,
+            "y" => Kind::Y,
+            "z" => Kind::Z,
+            "w" => Kind::W,
             _ => return None
         })
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2692,6 +2692,9 @@ impl Runtime {
                     Mul => Variable::Vec4([a[0] * b[0], a[1] * b[1], a[2] * b[2], a[3] * b[3]]),
                     Dot => Variable::F64((a[0] * b[0] + a[1] * b[1] +
                                           a[2] * b[2] + a[3] * b[3]) as f64),
+                    Cross => Variable::Vec4([a[1] * b[2] - a[2] * b[1],
+                                             a[2] * b[0] - a[0] * b[2],
+                                             a[0] * b[1] - a[1] * b[0], 0.0]),
                     Div => Variable::Vec4([a[0] / b[0], a[1] / b[1], a[2] / b[2], a[3] / b[3]]),
                     Rem => Variable::Vec4([a[0] % b[0], a[1] % b[1], a[2] % b[2], a[3] % b[3]]),
                     Pow => Variable::Vec4([a[0].powf(b[0]), a[1].powf(b[1]),
@@ -2706,10 +2709,13 @@ impl Runtime {
                     Mul => Variable::Vec4([a[0] * b, a[1] * b, a[2] * b, a[3] * b]),
                     Dot => Variable::F64((a[0] * b + a[1] * b +
                                           a[2] * b + a[3] * b) as f64),
+                    Cross => return Err(module.error(binop.source_range,
+                        &format!("{}\nExpected two vec4 for `{:?}`",
+                            self.stack_trace(), binop.op.symbol()))),
                     Div => Variable::Vec4([a[0] / b, a[1] / b, a[2] / b, a[3] / b]),
                     Rem => Variable::Vec4([a[0] % b, a[1] % b, a[2] % b, a[3] % b]),
                     Pow => Variable::Vec4([a[0].powf(b), a[1].powf(b),
-                                           a[2].powf(b), a[3].powf(b)])
+                                           a[2].powf(b), a[3].powf(b)]),
                 }
             }
             (&Variable::F64(a), &Variable::Vec4(b)) => {
@@ -2720,6 +2726,9 @@ impl Runtime {
                     Mul => Variable::Vec4([a * b[0], a * b[1], a * b[2], a * b[3]]),
                     Dot => Variable::F64((a * b[0] + a * b[1] +
                                           a * b[2] + a * b[3]) as f64),
+                    Cross => return Err(module.error(binop.source_range,
+                        &format!("{}\nExpected two vec4 for `{:?}`",
+                            self.stack_trace(), binop.op.symbol()))),
                     Div => Variable::Vec4([a / b[0], a / b[1], a / b[2], a / b[3]]),
                     Rem => Variable::Vec4([a % b[0], a % b[1], a % b[2], a % b[3]]),
                     Pow => Variable::Vec4([a.powf(b[0]), a.powf(b[1]),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -57,6 +57,7 @@ pub struct Runtime {
     pub rng: rand::ThreadRng,
     pub text_type: Variable,
     pub f64_type: Variable,
+    pub vec4_type: Variable,
     pub return_type: Variable,
     pub bool_type: Variable,
     pub object_type: Variable,
@@ -204,6 +205,7 @@ impl Runtime {
             rng: rand::thread_rng(),
             text_type: Variable::Text(Arc::new("string".into())),
             f64_type: Variable::Text(Arc::new("number".into())),
+            vec4_type: Variable::Text(Arc::new("vec4".into())),
             return_type: Variable::Text(Arc::new("return".into())),
             bool_type: Variable::Text(Arc::new("boolean".into())),
             object_type: Variable::Text(Arc::new("object".into())),
@@ -343,6 +345,9 @@ impl Runtime {
             Number(ref num) => {
                 self.number(num);
                 Ok((Expect::Something, Flow::Continue))
+            }
+            Vec4(ref vec4) => {
+                Ok((Expect::Something, try!(self.vec4(vec4, side, module))))
             }
             Text(ref text) => {
                 self.text(text);
@@ -846,6 +851,44 @@ impl Runtime {
                                     _ => return Err(module.error(
                                             left.source_range(),
                                             &format!("{}\nExpected assigning to a number",
+                                                self.stack_trace())))
+                                };
+                            }
+                        }
+                        &Variable::Vec4(b) => {
+                            unsafe {
+                                match *r {
+                                    Variable::Vec4(ref mut n) => {
+                                        match op {
+                                            Set => *n = b,
+                                            Add => *n = [n[0] + b[0], n[1] + b[1],
+                                                         n[2] + b[2], n[3] + b[3]],
+                                            Sub => *n = [n[0] - b[0], n[1] - b[1],
+                                                         n[2] - b[2], n[3] - b[3]],
+                                            Mul => *n = [n[0] * b[0], n[1] * b[1],
+                                                         n[2] * b[2], n[3] * b[3]],
+                                            Div => *n = [n[0] / b[0], n[1] / b[1],
+                                                         n[2] / b[2], n[3] / b[3]],
+                                            Rem => *n = [n[0] % b[0], n[1] % b[1],
+                                                         n[2] % b[2], n[3] % b[3]],
+                                            Pow => *n = [n[0].powf(b[0]), n[1].powf(b[1]),
+                                                         n[2].powf(b[2]), n[3].powf(b[3])],
+                                            Assign => {}
+                                        }
+                                    }
+                                    Variable::Return => {
+                                        if let Set = op {
+                                            *r = Variable::Vec4(b)
+                                        } else {
+                                            return Err(module.error(
+                                                left.source_range(),
+                                                &format!("{}\nReturn has no value",
+                                                    self.stack_trace())))
+                                        }
+                                    }
+                                    _ => return Err(module.error(
+                                            left.source_range(),
+                                            &format!("{}\nExpected assigning to a vec4",
                                                 self.stack_trace())))
                                 };
                             }
@@ -1361,6 +1404,7 @@ impl Runtime {
         let v = match var {
             &Variable::Text(_) => self.text_type.clone(),
             &Variable::F64(_) => self.f64_type.clone(),
+            &Variable::Vec4(_) => self.vec4_type.clone(),
             &Variable::Return => self.return_type.clone(),
             &Variable::Bool(_) => self.bool_type.clone(),
             &Variable::Object(_) => self.object_type.clone(),
@@ -2511,6 +2555,48 @@ impl Runtime {
     fn number(&mut self, num: &ast::Number) {
         self.stack.push(Variable::F64(num.num));
     }
+    fn vec4(
+        &mut self,
+        vec4: &ast::Vec4,
+        side: Side,
+        module: &Module
+    ) -> Result<Flow, String> {
+        for expr in &vec4.args {
+            match try!(self.expression(expr, side, module)) {
+                (_, Flow::Return) => { return Ok(Flow::Return); }
+                (Expect::Something, Flow::Continue) => {}
+                _ => return Err(module.error(expr.source_range(),
+                    &format!("{}\nExpected something from vec4 argument",
+                        self.stack_trace())))
+            };
+        }
+        let w = self.stack.pop().expect("There is no value on the stack");
+        let w = match self.resolve(&w) {
+            &Variable::F64(val) => val,
+            x => return Err(module.error(vec4.args[3].source_range(),
+                &self.expected(x, "number")))
+        };
+        let z = self.stack.pop().expect("There is no value on the stack");
+        let z = match self.resolve(&z) {
+            &Variable::F64(val) => val,
+            x => return Err(module.error(vec4.args[2].source_range(),
+                &self.expected(x, "number")))
+        };
+        let y = self.stack.pop().expect("There is no value on the stack");
+        let y = match self.resolve(&y) {
+            &Variable::F64(val) => val,
+            x => return Err(module.error(vec4.args[1].source_range(),
+                &self.expected(x, "number")))
+        };
+        let x = self.stack.pop().expect("There is no value on the stack");
+        let x = match self.resolve(&x) {
+            &Variable::F64(val) => val,
+            x => return Err(module.error(vec4.args[0].source_range(),
+                &self.expected(x, "number")))
+        };
+        self.stack.push(Variable::Vec4([x as f32, y as f32, z as f32, w as f32]));
+        Ok(Flow::Continue)
+    }
     #[inline(always)]
     fn bool(&mut self, val: &ast::Bool) {
         self.stack.push(Variable::Bool(val.val));
@@ -2530,6 +2616,14 @@ impl Runtime {
         };
         let val = self.stack.pop().expect("Expected unary argument");
         let v = match self.resolve(&val) {
+            &Variable::Vec4(b) => {
+                Variable::F64(match unop.op {
+                    ast::UnOp::Norm => (b[0] * b[0] + b[1] * b[1] + b[2] * b[2]).sqrt() as f64,
+                    _ => return Err(module.error(unop.source_range,
+                                    &format!("{}\nUnknown vec4 unary operator",
+                                             self.stack_trace())))
+                })
+            }
             &Variable::Bool(b) => {
                 Variable::Bool(match unop.op {
                     ast::UnOp::Not => !b,
@@ -2584,8 +2678,53 @@ impl Runtime {
                     Mul => a * b,
                     Div => a / b,
                     Rem => a % b,
-                    Pow => a.powf(b)
+                    Pow => a.powf(b),
+                    _ => return Err(module.error(binop.source_range,
+                        &format!("{}\nUnknown number operator `{:?}`",
+                            self.stack_trace(),
+                            binop.op.symbol())))
                 })
+            }
+            (&Variable::Vec4(a), &Variable::Vec4(b)) => {
+                match binop.op {
+                    Add => Variable::Vec4([a[0] + b[0], a[1] + b[1], a[2] + b[2], a[3] + b[3]]),
+                    Sub => Variable::Vec4([a[0] - b[0], a[1] - b[1], a[2] - b[2], a[3] - b[3]]),
+                    Mul => Variable::Vec4([a[0] * b[0], a[1] * b[1], a[2] * b[2], a[3] * b[3]]),
+                    Dot => Variable::F64((a[0] * b[0] + a[1] * b[1] +
+                                          a[2] * b[2] + a[3] * b[3]) as f64),
+                    Div => Variable::Vec4([a[0] / b[0], a[1] / b[1], a[2] / b[2], a[3] / b[3]]),
+                    Rem => Variable::Vec4([a[0] % b[0], a[1] % b[1], a[2] % b[2], a[3] % b[3]]),
+                    Pow => Variable::Vec4([a[0].powf(b[0]), a[1].powf(b[1]),
+                                           a[2].powf(b[2]), a[3].powf(b[3])])
+                }
+            }
+            (&Variable::Vec4(a), &Variable::F64(b)) => {
+                let b = b as f32;
+                match binop.op {
+                    Add => Variable::Vec4([a[0] + b, a[1] + b, a[2] + b, a[3] + b]),
+                    Sub => Variable::Vec4([a[0] - b, a[1] - b, a[2] - b, a[3] - b]),
+                    Mul => Variable::Vec4([a[0] * b, a[1] * b, a[2] * b, a[3] * b]),
+                    Dot => Variable::F64((a[0] * b + a[1] * b +
+                                          a[2] * b + a[3] * b) as f64),
+                    Div => Variable::Vec4([a[0] / b, a[1] / b, a[2] / b, a[3] / b]),
+                    Rem => Variable::Vec4([a[0] % b, a[1] % b, a[2] % b, a[3] % b]),
+                    Pow => Variable::Vec4([a[0].powf(b), a[1].powf(b),
+                                           a[2].powf(b), a[3].powf(b)])
+                }
+            }
+            (&Variable::F64(a), &Variable::Vec4(b)) => {
+                let a = a as f32;
+                match binop.op {
+                    Add => Variable::Vec4([a + b[0], a + b[1], a + b[2], a + b[3]]),
+                    Sub => Variable::Vec4([a - b[0], a - b[1], a - b[2], a - b[3]]),
+                    Mul => Variable::Vec4([a * b[0], a * b[1], a * b[2], a * b[3]]),
+                    Dot => Variable::F64((a * b[0] + a * b[1] +
+                                          a * b[2] + a * b[3]) as f64),
+                    Div => Variable::Vec4([a / b[0], a / b[1], a / b[2], a / b[3]]),
+                    Rem => Variable::Vec4([a % b[0], a % b[1], a % b[2], a % b[3]]),
+                    Pow => Variable::Vec4([a.powf(b[0]), a.powf(b[1]),
+                                           a.powf(b[2]), a.powf(b[3])])
+                }
             }
             (&Variable::Bool(a), &Variable::Bool(b)) => {
                 Variable::Bool(match binop.op {
@@ -2619,7 +2758,7 @@ impl Runtime {
                 Try the `to_string` function", self.stack_trace()))),
             _ => return Err(module.error(binop.source_range, &format!(
                 "{}\nInvalid type for binary operator `{:?}`, \
-                expected numbers, bools or strings",
+                expected numbers, vec4s, bools or strings",
                 self.stack_trace(),
                 binop.op.symbol())))
         };

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,7 +6,7 @@ use dyon::*;
 pub fn test_src(source: &str) {
     let mut module = Module::new();
     load(source, &mut module).unwrap_or_else(|err| {
-        panic!("{}", err);
+        panic!("In `{}`:\n{}", source, err);
     });
 }
 
@@ -21,7 +21,7 @@ pub fn test_fail_src(source: &str) {
 pub fn debug_src(source: &str) {
     let mut module = Module::new();
     load(source, &mut module).unwrap_or_else(|err| {
-        panic!("{}", err);
+        panic!("In `{}`:\n{}", source, err);
     });
     panic!("{:?}", module.functions);
 }
@@ -67,6 +67,7 @@ fn test_syntax() {
     test_src("source/syntax/accessor.rs");
     test_src("source/syntax/sum.rs");
     test_src("source/syntax/min_max.rs");
+    test_src("source/syntax/vec4.rs");
 }
 
 #[test]


### PR DESCRIPTION
See https://github.com/PistonDevelopers/dyon/issues/130

Design: https://github.com/PistonDevelopers/dyon/issues/144

### Performance

This leads to 2.8x improvement in performance for the n_body example:

```
Before:
test tests::bench_add         ... bench:  43,393,867 ns/iter (+/- 6,806,476)
test tests::bench_add_n       ... bench:  15,092,144 ns/iter (+/- 3,001,957)
test tests::bench_array       ... bench:  18,773,838 ns/iter (+/- 3,739,800)
test tests::bench_call        ... bench:  17,788,675 ns/iter (+/- 3,720,407)
test tests::bench_len         ... bench:   3,382,249 ns/iter (+/- 205,532)
test tests::bench_main        ... bench:   1,891,454 ns/iter (+/- 157,257)
test tests::bench_min         ... bench:  16,661,012 ns/iter (+/- 2,141,291)
test tests::bench_min_fn      ... bench:  81,098,014 ns/iter (+/- 7,106,106)
test tests::bench_n_body      ... bench: 208,976,966 ns/iter (+/- 18,541,989) <---
test tests::bench_object      ... bench:  27,482,168 ns/iter (+/- 5,447,122)
test tests::bench_primes      ... bench:  48,065,297 ns/iter (+/- 5,965,289)
test tests::bench_primes_trad ... bench:  45,867,012 ns/iter (+/- 6,662,685)
test tests::bench_sum         ... bench:   6,830,854 ns/iter (+/- 614,111)

After:
test tests::bench_add         ... bench:  42,161,587 ns/iter (+/- 5,777,769)
test tests::bench_add_n       ... bench:  15,811,724 ns/iter (+/- 3,484,295)
test tests::bench_array       ... bench:  18,372,826 ns/iter (+/- 3,036,913)
test tests::bench_call        ... bench:  17,736,857 ns/iter (+/- 2,506,030)
test tests::bench_len         ... bench:   3,516,452 ns/iter (+/- 187,508)
test tests::bench_main        ... bench:   2,004,404 ns/iter (+/- 541,539)
test tests::bench_min         ... bench:  17,647,011 ns/iter (+/- 3,824,137)
test tests::bench_min_fn      ... bench:  81,071,483 ns/iter (+/- 7,499,528)
test tests::bench_n_body      ... bench:  75,921,824 ns/iter (+/- 6,012,761) <---
test tests::bench_object      ... bench:  26,914,886 ns/iter (+/- 5,105,781)
test tests::bench_primes      ... bench:  47,865,836 ns/iter (+/- 4,815,001)
test tests::bench_primes_trad ... bench:  45,441,088 ns/iter (+/- 5,097,709)
test tests::bench_sum         ... bench:   6,895,172 ns/iter (+/- 333,311)

(old_bench_n_body - old_bench_main) / (new_bench_n_body - new_bench_main)
= (208976966 - 1891454) / (75921824 - 2004404)
= 2.8015792759000515
```