### PR TITLE
Compare always returns `bool`

### DIFF
--- a/source/syntax/compare.dyon
+++ b/source/syntax/compare.dyon
@@ -1,3 +1,3 @@
-fn ls(x, y) {
-    x < y
+fn ls(x, y) -> {
+    return x < y
 }

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -288,6 +288,7 @@ pub fn convert_meta_data(
                     Kind::Object => Some(Type::object()),
                     Kind::Sum => Some(Type::F64),
                     Kind::Swizzle => Some(Type::F64),
+                    Kind::Compare => Some(Type::Bool),
                     _ => None
                 };
 


### PR DESCRIPTION
- Fixed “syntax/compare.dyon”