### PR TITLE
Fixed `Variable` size

### DIFF
--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -443,11 +443,11 @@ pub fn call_standard(
         "tail" => {
             rt.push_fn(call.name.clone(), 0, None, st + 1, lc, cu);
             let v = rt.stack.pop().expect(TINVOTS);
-            let v = Variable::Link(match rt.resolve(&v) {
+            let v = Variable::Link(Box::new(match rt.resolve(&v) {
                 &Variable::Link(ref link) => link.tail(),
                 x => return Err(module.error(call.args[0].source_range(),
                                 &rt.expected(x, "link"), rt))
-            });
+            }));
             rt.stack.push(v);
             rt.pop_fn(call.name.clone());
             Expect::Something

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub enum Variable {
     Text(Arc<String>),
     Array(Array),
     Object(Object),
-    Link(Link),
+    Link(Box<Link>),
     UnsafeRef(UnsafeRef),
     RustObject(RustObject),
     Option(Option<Box<Variable>>),
@@ -384,6 +384,35 @@ mod tests {
 
     use super::run;
     use self::test::Bencher;
+
+    #[test]
+    fn variable_size() {
+        use std::mem::size_of;
+        use super::*;
+
+        /*
+        Ref(usize),
+        Return,
+        Bool(bool),
+        F64(f64),
+        Vec4([f32; 4]),
+        Text(Arc<String>),
+        Array(Array),
+        Object(Object),
+        Link(Link),
+        UnsafeRef(UnsafeRef),
+        RustObject(RustObject),
+        Option(Option<Box<Variable>>),
+        Result(Result<Box<Variable>, Box<Error>>),
+        Thread(Thread),
+        */
+
+        println!("Link {}", size_of::<Link>());
+        println!("[f32; 4] {}", size_of::<[f32; 4]>());
+        println!("Result {}", size_of::<Result<Box<Variable>, Box<Error>>>());
+        println!("Thread {}", size_of::<Thread>());
+        assert_eq!(size_of::<Variable>(), 24);
+    }
 
     fn run_bench(source: &str) {
         run(source).unwrap_or_else(|err| panic!("{}", err));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -838,7 +838,7 @@ impl Runtime {
         use Link;
 
         if link.items.len() == 0 {
-            self.stack.push(Variable::Link(Link::new()));
+            self.stack.push(Variable::Link(Box::new(Link::new())));
         } else {
             let mut new_link = Link::new();
             for item in &link.items {
@@ -859,7 +859,7 @@ impl Runtime {
                     Ok(()) => {}
                 }
             }
-            self.stack.push(Variable::Link(new_link));
+            self.stack.push(Variable::Link(Box::new(new_link)));
         }
         Ok(Flow::Continue)
     }
@@ -1282,8 +1282,8 @@ impl Runtime {
                                     Variable::Link(ref mut n) => {
                                         match op {
                                             Set => *n = b.clone(),
-                                            Add => *n = n.add(b),
-                                            Sub => *n = b.add(n),
+                                            Add => **n = n.add(b),
+                                            Sub => **n = b.add(n),
                                             _ => unimplemented!()
                                         }
                                     }
@@ -3327,7 +3327,7 @@ impl Runtime {
             (&Variable::Link(ref a), &Variable::Link(ref b)) => {
                 match binop.op {
                     Add => {
-                        Variable::Link(a.add(b))
+                        Variable::Link(Box::new(a.add(b)))
                     }
                     _ => return Err(module.error(binop.source_range,
                         &format!("{}\nThis operation can not be used with links",


### PR DESCRIPTION
`Link` takes 24 bytes, so the size of `Variable` became 32. It should
be 24.

- Changed to `Link(Box<Link>)`