### PR TITLE
Fixed bug in `Runtime::call`

### DIFF
--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,11 +1,9 @@
+fn foo() -> res {
+    err("")?
+}
+
 fn main() {
-    println(unwrap(bar(2)))
-}
-
-fn foo(x) -> res {
-    return ok(ok("hi")?)
-}
-
-fn bar(x) -> res {
-    return ok(foo(x)?)
+    data := 2
+    _ := foo()
+    println(data)
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -750,11 +750,7 @@ impl Runtime {
                                 self.stack_trace(),
                                 f.name), source))
                     }
-                    (true, Some(ref x))
-                        if match x {
-                            &Variable::Return => true,
-                            _ => false
-                        } => {
+                    (true, Some(Variable::Return)) => {
                         // TODO: Could return the last value on the stack.
                         //       Requires .pop_fn delayed after.
                         let source = call.custom_source.as_ref().unwrap_or(
@@ -767,7 +763,8 @@ impl Runtime {
                                 self.stack_trace(),
                                 f.name), source))
                     }
-                    (_, b) => {
+                    (returns, b) => {
+                        if returns { self.stack.pop(); }
                         return Ok((b, Flow::Continue))
                     }
                 }


### PR DESCRIPTION
The return variable was left on the stack after the call.