### PR TITLE
Fixed bug when index out of bounds with `?` operator

### DIFF
--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,5 +1,8 @@
 fn main() {
-    list := sift i [1, 100) { if (i % 13) != 0 { continue } else { clone(i) } }
-    println(list)
-    println(prod i { list[i] })
+    println(foo()?)
+}
+
+fn foo() -> res {
+    list := []
+    return ok(list[0])
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -449,9 +449,9 @@ impl Runtime {
         side: Side,
         module: &Module
     ) -> Result<(Option<Variable>, Flow), String> {
-        let v = match self.expression(expr, side, module) {
-            Ok((Some(x), Flow::Continue)) => x,
-            Ok((x, Flow::Return)) => { return Ok((x, Flow::Return)); }
+        let v = match try!(self.expression(expr, side, module)) {
+            (Some(x), Flow::Continue) => x,
+            (x, Flow::Return) => { return Ok((x, Flow::Return)); }
             _ => return Err(module.error(expr.source_range(),
                             &format!("{}\nExpected something",
                                 self.stack_trace()), self))


### PR DESCRIPTION
The `?` operator was overriding the index out of bounds error.