### PR TITLE
Bootstrapped conversion rules

### DIFF
--- a/meta/test_bootstrap/convert.txt
+++ b/meta/test_bootstrap/convert.txt
@@ -23,7 +23,11 @@ meta {
     sel := repeat ref:"ref";
     select := [sel <- sel]
         => {op: "select", rules: sel};
-    rule := select {fields:"fields", repeat:"repeat", select:"select"};
+    rule := select {
+            fields:"fields",
+            repeat:"repeat",
+            select:"select"
+        };
     decl := [name: str, rule <- rule:"rule"]
         => if rule.op == "fields" {
             {name: name, fields: rule.fields, expr: rule.expr}
@@ -35,6 +39,6 @@ meta {
     rules := repeat decl:"decl";
     doc := [rules <- rules:"rules", start: str]
         => {rules: rules, start: start};
-    ------------------------------------------------------------
+    -----------------------------------------------------------
     doc
 }

--- a/meta/test_bootstrap/convert.txt
+++ b/meta/test_bootstrap/convert.txt
@@ -20,26 +20,19 @@ meta {
         => {op: "fields", fields: fs, expr: expr};
     repeat := [ref <- ref]
         => {op: "repeat", rule: ref.rule, as: ref.as};
-    select := repeat ref:"ref";
+    sel := repeat ref:"ref";
+    select := [sel <- sel]
+        => {op: "select", rules: sel};
     rule := select {fields:"fields", repeat:"repeat", select:"select"};
     decl := [name: str, rule <- rule:"rule"]
         => if typeof(rule) == "object" {
               if rule.op == "fields" {
-                  {
-                      name: clone(name),
-                      fields: clone(rule.fields),
-                      expr: clone(rule.expr)
-                  }
+                  {name: name, fields: rule.fields, expr: rule.expr}
               } else if rule.op == "repeat" {
-                  {
-                      name: clone(name),
-                      repeat: {rule: clone(rule.rule), as: clone(rule.as)}
-                  }
+                  {name: name, repeat: {rule: rule.rule, as: rule.as}}
+              } else if rule.op == "select" {
+                  {name: name, select: rule.rules}
               }
-          } else if typeof(rule) == "array" {
-              {name: clone(name), select: sift i {
-                  {rule: clone(rule[i].rule), as: clone(rule[i].as)}
-              }}
           };
     rules := repeat decl:"decl";
     doc := [rules <- rules:"rules", start: str]

--- a/meta/test_bootstrap/convert.txt
+++ b/meta/test_bootstrap/convert.txt
@@ -1,10 +1,10 @@
 meta {
-    f64 := [f64: bool] => {op: "type", val: "f64"};
-    str := [str: bool] => {op: "type", val: "str"};
-    bool := [bool: bool] => {op: "type", val: "bool"};
+    f64 := [f64: bool] => str("f64");
+    str := [str: bool] => str("str");
+    bool := [bool: bool] => str("bool");
     ty := select {f64, str, bool};
     type := [opt: opt[bool], ty <- ty]
-        => {op: ty.op, val: ty.val, optional: opt == some(true)};
+        => {op: "type", val: ty, optional: opt == some(true)};
     ref := [rule: str, as: opt[str]]
         => {op: "ref", rule: rule, as: as};
     type_or_ref := select {type, ref};

--- a/meta/test_bootstrap/convert.txt
+++ b/meta/test_bootstrap/convert.txt
@@ -25,15 +25,13 @@ meta {
         => {op: "select", rules: sel};
     rule := select {fields:"fields", repeat:"repeat", select:"select"};
     decl := [name: str, rule <- rule:"rule"]
-        => if typeof(rule) == "object" {
-              if rule.op == "fields" {
-                  {name: name, fields: rule.fields, expr: rule.expr}
-              } else if rule.op == "repeat" {
-                  {name: name, repeat: {rule: rule.rule, as: rule.as}}
-              } else if rule.op == "select" {
-                  {name: name, select: rule.rules}
-              }
-          };
+        => if rule.op == "fields" {
+            {name: name, fields: rule.fields, expr: rule.expr}
+        } else if rule.op == "repeat" {
+            {name: name, repeat: {rule: rule.rule, as: rule.as}}
+        } else if rule.op == "select" {
+            {name: name, select: rule.rules}
+        };
     rules := repeat decl:"decl";
     doc := [rules <- rules:"rules", start: str]
         => {rules: rules, start: start};

--- a/meta/test_bootstrap/data.txt
+++ b/meta/test_bootstrap/data.txt
@@ -1,8 +1,44 @@
 meta {
-    john := [john: bool] => {first_name: "John"};
-    peter := [peter: bool] => {first_name: "Peter"};
-    person := select {john, peter};
-    people := repeat person:"person";
-    ------------------------------------------------
-    people
+    f64 := [f64: bool] => str("f64");
+    str := [str: bool] => str("str");
+    bool := [bool: bool] => str("bool");
+    ty := select {f64, str, bool};
+    type := [opt: opt[bool], ty <- ty]
+        => {op: "type", val: ty, optional: opt == some(true)};
+    ref := [rule: str, as: opt[str]]
+        => {op: "ref", rule: rule, as: as};
+    type_or_ref := select {type, ref};
+    field := [name: str, tr <- type_or_ref]
+        => if tr.op == "type" {
+            {name: name, type: tr.val, optional: tr.optional}
+        } else {
+            {name: name, ref: {rule: tr.rule, as: tr.as}}
+        };
+    rep_fields := repeat field:"field";
+    expr := [code: str] => code;
+    fields := [fs <- rep_fields, expr <- expr:"expr"]
+        => {op: "fields", fields: fs, expr: expr};
+    repeat := [ref <- ref]
+        => {op: "repeat", rule: ref.rule, as: ref.as};
+    sel := repeat ref:"ref";
+    select := [sel <- sel]
+        => {op: "select", rules: sel};
+    rule := select {
+            fields:"fields",
+            repeat:"repeat",
+            select:"select"
+        };
+    decl := [name: str, rule <- rule:"rule"]
+        => if rule.op == "fields" {
+            {name: name, fields: rule.fields, expr: rule.expr}
+        } else if rule.op == "repeat" {
+            {name: name, repeat: {rule: rule.rule, as: rule.as}}
+        } else if rule.op == "select" {
+            {name: name, select: rule.rules}
+        };
+    rules := repeat decl:"decl";
+    doc := [rules <- rules:"rules", start: str]
+        => {rules: rules, start: start};
+    -----------------------------------------------------------
+    doc
 }

--- a/meta/test_bootstrap/nice.dyon
+++ b/meta/test_bootstrap/nice.dyon
@@ -1,38 +1,153 @@
 {
+    start: "doc",
     rules: [
         {
-            name: "john",
-            expr: "{first_name: \"John\"}",
-            fields: [
-                {
-                    name: "john",
-                    type: "bool",
-                    optional: false
-                }
-            ]
+            expr: "str(\"f64\")",
+            fields: [{type: "bool", optional: false, name: "f64"}],
+            name: "f64"
         },
         {
-            name: "peter",
-            expr: "{first_name: \"Peter\"}",
-            fields: [
-                {
-                    name: "peter",
-                    type: "bool",
-                    optional: false
-                }
-            ]
+            expr: "str(\"str\")",
+            fields: [{type: "bool", optional: false, name: "str"}],
+            name: "str"
+        },
+        {
+            expr: "str(\"bool\")",
+            fields: [{type: "bool", optional: false, name: "bool"}],
+            name: "bool"
         },
         {
             select: [
-                {rule: "john", as: none(), op: "ref"},
-                {rule: "peter", as: none(), op: "ref"}
+                {as: none(), op: "ref", rule: "f64"},
+                {as: none(), op: "ref", rule: "str"},
+                {as: none(), op: "ref", rule: "bool"}
             ],
-            name: "person"
+            name: "ty"
         },
         {
-            name: "people",
-            repeat: {rule: "person", as: some("person")}
+            expr: "{op: \"type\", val: ty, optional: opt == some(true)}",
+            fields: [
+                {type: "bool", optional: true, name: "opt"},
+                {ref: {as: none(), rule: "ty"}, name: "ty"}
+            ],
+            name: "type"
+        },
+        {
+            expr: "{op: \"ref\", rule: rule, as: as}",
+            fields: [
+                {type: "str", optional: false, name: "rule"},
+                {type: "str", optional: true, name: "as"}
+            ],
+            name: "ref"
+        },
+        {
+            select: [
+                {as: none(), op: "ref", rule: "type"},
+                {as: none(), op: "ref", rule: "ref"}
+            ],
+            name: "type_or_ref"
+        },
+        {
+            expr: "if tr.op == \"type\" {
+                {name: name, type: tr.val, optional: tr.optional}
+            } else {
+                {name: name, ref: {rule: tr.rule, as: tr.as}}
+            }",
+            fields: [
+                {type: "str", optional: false, name: "name"},
+                {
+                    ref: {as: none(), rule: "type_or_ref"},
+                    name: "tr"
+                }
+            ],
+            name: "field"
+        },
+        {
+            repeat: {as: some("field"), rule: "field"},
+            name: "rep_fields"
+        },
+        {
+            expr: "code",
+            fields: [{type: "str", optional: false, name: "code"}],
+            name: "expr"
+        },
+        {
+            expr: "{op: \"fields\", fields: fs, expr: expr}",
+            fields: [
+                {
+                    ref: {as: none(), rule: "rep_fields"},
+                    name: "fs"
+                },
+                {
+                    ref: {as: some("expr"), rule: "expr"},
+                    name: "expr"
+                }
+            ],
+            name: "fields"
+        },
+        {
+            expr: "{op: \"repeat\", rule: ref.rule, as: ref.as}",
+            fields: [
+                {
+                    ref: {as: none(), rule: "ref"},
+                    name: "ref"
+                }
+            ],
+            name: "repeat"
+        },
+        {
+            repeat: {as: some("ref"), rule: "ref"},
+            name: "sel"
+        },
+        {
+            expr: "{op: \"select\", rules: sel}",
+            fields: [
+                {
+                    ref: {as: none(), rule: "sel"},
+                    name: "sel"
+                }
+            ],
+            name: "select"
+        },
+        {
+            select: [
+                {as: some("fields"), op: "ref", rule: "fields"},
+                {as: some("repeat"), op: "ref", rule: "repeat"},
+                {as: some("select"), op: "ref", rule: "select"}
+            ],
+            name: "rule"
+        },
+        {
+            expr: "if rule.op == \"fields\" {
+                {name: name, fields: rule.fields, expr: rule.expr}
+            } else if rule.op == \"repeat\" {
+                {name: name, repeat: {rule: rule.rule, as: rule.as}}
+            } else if rule.op == \"select\" {
+                {name: name, select: rule.rules}
+            }",
+            fields: [
+                {type: "str", optional: false, name: "name"},
+                {
+                    ref: {as: some("rule"), rule: "rule"},
+                    name: "rule"
+                }
+            ],
+            name: "decl"
+        },
+        {
+            repeat: {as: some("decl"), rule: "decl"},
+            name: "rules"
+        },
+        {
+            expr: "{rules: rules, start: start}",
+            fields: [
+                {
+                    ref: {as: some("rules"), rule: "rules"},
+                    name: "rules"
+                },
+                {type: "str", optional: false, name: "start"}
+            ],
+            name: "doc"
         }
-    ],
-    start: "people"
+    ]
 }

--- a/meta/test_bootstrap/nice.dyon
+++ b/meta/test_bootstrap/nice.dyon
@@ -2,27 +2,36 @@
     rules: [
         {
             name: "john",
+            expr: "{first_name: \"John\"}",
             fields: [
-                {name: "john", optional: false, type: "bool"}
-            ],
-            expr: "{first_name: \"John\"}"
-        },
-        {
-            name: "peter",
-            fields: [
-                {name: "peter", optional: false, type: "bool"}
-            ],
-            expr: "{first_name: \"Peter\"}"
-        },
-        {
-            name: "person", select: [
-                {as: none(), rule: "john"},
-                {as: none(), rule: "peter"}
+                {
+                    name: "john",
+                    type: "bool",
+                    optional: false
+                }
             ]
         },
         {
+            name: "peter",
+            expr: "{first_name: \"Peter\"}",
+            fields: [
+                {
+                    name: "peter",
+                    type: "bool",
+                    optional: false
+                }
+            ]
+        },
+        {
+            select: [
+                {rule: "john", as: none(), op: "ref"},
+                {rule: "peter", as: none(), op: "ref"}
+            ],
+            name: "person"
+        },
+        {
             name: "people",
-            repeat: {as: some("person"), rule: "person"}
+            repeat: {rule: "person", as: some("person")}
         }
     ],
     start: "people"

--- a/meta/test_bootstrap/output.dyon
+++ b/meta/test_bootstrap/output.dyon
@@ -483,7 +483,7 @@ fn __repeat__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     return ok([I - S, {op: "repeat", rule: ref.rule, as: ref.as}])
 }
 
-fn __select__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
+fn __sel__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     S := index
     I := index
     if name != none() {
@@ -506,6 +506,43 @@ fn __select__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
         I += end_node(data: data, index: I, name: unwrap(name))?
     }
     return ok([I - S, arr])
+}
+
+fn __select__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
+    S := index
+    I := index
+    if name != none() {
+        node := start_node(data: data, index: I, name: unwrap(name))
+        if node == none() { return err("Expected `" + unwrap(name) + "`")? }
+        I += unwrap(node)
+    }
+    _sel := none()
+    loop {
+        if I >= len(data) { break }
+        if (_sel != none()) { break }
+        i_sel := __sel(data: data, index: I, name: none())
+        if !is_err(i_sel) {
+            i_sel := unwrap(i_sel)
+            if i_sel[0] > 0 {
+                I += i_sel[0]
+                _sel = some(i_sel[1])
+                continue
+            }
+        }
+        if name != none() {
+            I += ignore(data: data, index: I)
+        }
+        break
+    }
+    if name != none() {
+        I += end_node(data: data, index: I, name: unwrap(name))?
+    }
+    sel := if _sel != none() {
+        unwrap(_sel)
+    } else {
+        return err("Could not find `sel`")?
+    }
+    return ok([I - S, {op: "select", rules: sel}])
 }
 
 fn __rule__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
@@ -598,21 +635,12 @@ fn __decl__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     }
     return ok([I - S, if typeof(rule) == "object" {
               if rule.op == "fields" {
-                  {
-                      name: clone(name),
-                      fields: clone(rule.fields),
-                      expr: clone(rule.expr)
-                  }
+                  {name: name, fields: rule.fields, expr: rule.expr}
               } else if rule.op == "repeat" {
-                  {
-                      name: clone(name),
-                      repeat: {rule: clone(rule.rule), as: clone(rule.as)}
-                  }
+                  {name: name, repeat: {rule: rule.rule, as: rule.as}}
+              } else if rule.op == "select" {
+                  {name: name, select: rule.rules}
               }
-          } else if typeof(rule) == "array" {
-              {name: clone(name), select: sift i {
-                  {rule: clone(rule[i].rule), as: clone(rule[i].as)}
-              }}
           }])
 }
 

--- a/meta/test_bootstrap/output.dyon
+++ b/meta/test_bootstrap/output.dyon
@@ -633,15 +633,13 @@ fn __decl__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     } else {
         return err("Could not find `rule`")?
     }
-    return ok([I - S, if typeof(rule) == "object" {
-              if rule.op == "fields" {
-                  {name: name, fields: rule.fields, expr: rule.expr}
-              } else if rule.op == "repeat" {
-                  {name: name, repeat: {rule: rule.rule, as: rule.as}}
-              } else if rule.op == "select" {
-                  {name: name, select: rule.rules}
-              }
-          }])
+    return ok([I - S, if rule.op == "fields" {
+            {name: name, fields: rule.fields, expr: rule.expr}
+        } else if rule.op == "repeat" {
+            {name: name, repeat: {rule: rule.rule, as: rule.as}}
+        } else if rule.op == "select" {
+            {name: name, select: rule.rules}
+        }])
 }
 
 fn __rules__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {

--- a/meta/test_bootstrap/output.dyon
+++ b/meta/test_bootstrap/output.dyon
@@ -32,7 +32,7 @@ fn __f64__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     } else {
         return err("Could not find `f64`")?
     }
-    return ok([I - S, {op: "type", val: "f64"}])
+    return ok([I - S, str("f64")])
 }
 
 fn __str__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
@@ -69,7 +69,7 @@ fn __str__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     } else {
         return err("Could not find `str`")?
     }
-    return ok([I - S, {op: "type", val: "str"}])
+    return ok([I - S, str("str")])
 }
 
 fn __bool__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
@@ -106,7 +106,7 @@ fn __bool__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     } else {
         return err("Could not find `bool`")?
     }
-    return ok([I - S, {op: "type", val: "bool"}])
+    return ok([I - S, str("bool")])
 }
 
 fn __ty__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
@@ -193,7 +193,7 @@ fn __type__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {
     } else {
         return err("Could not find `ty`")?
     }
-    return ok([I - S, {op: ty.op, val: ty.val, optional: opt == some(true)}])
+    return ok([I - S, {op: "type", val: ty, optional: opt == some(true)}])
 }
 
 fn __ref__data_index_name(data: [[]], index: f64, name: opt[str]) -> res {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,18 +406,19 @@ mod tests {
     #[test]
     fn variable_size() {
         use std::mem::size_of;
+        use std::sync::Arc;
         use super::*;
 
         /*
         Ref(usize),
         Return,
-        Bool(bool),
-        F64(f64),
+        Bool(bool, Option<Box<Vec<Variable>>>),
+        F64(f64, Option<Box<Vec<Variable>>>),
         Vec4([f32; 4]),
         Text(Arc<String>),
         Array(Array),
         Object(Object),
-        Link(Link),
+        Link(Box<Link>),
         UnsafeRef(UnsafeRef),
         RustObject(RustObject),
         Option(Option<Box<Variable>>),
@@ -425,10 +426,14 @@ mod tests {
         Thread(Thread),
         */
 
-        println!("Link {}", size_of::<Link>());
+        println!("Link {}", size_of::<Box<Link>>());
         println!("[f32; 4] {}", size_of::<[f32; 4]>());
         println!("Result {}", size_of::<Result<Box<Variable>, Box<Error>>>());
         println!("Thread {}", size_of::<Thread>());
+        println!("Secret {}", size_of::<Option<Box<Vec<Variable>>>>());
+        println!("Text {}", size_of::<Arc<String>>());
+        println!("Array {}", size_of::<Array>());
+        println!("Object {}", size_of::<Object>());
         assert_eq!(size_of::<Variable>(), 24);
     }
 


### PR DESCRIPTION
The DSL for meta data to Dyon data structure conversion is now powerful enough to convert its own rules, therefore "bootstrapping" itself from meta data to Dyon data structure.

This means a new code generator can be written that takes converted rules described with a Dyon structure instead of meta data. The bootstrapped rules can be stored as Dyon code. It will make it easier to add features to the DSL and easier to write new code generators.