### PR TITLE
call_str

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -977,10 +977,10 @@ impl Runtime {
         }
     }
     
-    pub fn call_str(&mut self, fn_: &str, module: &Module) -> Result<(), String> {
+    pub fn call_str(&mut self, function: &str, module: &Module) -> Result<(), String> {
         use std::cell::Cell;
 
-        let name: Arc<String> = Arc::new(fn_.into());
+        let name: Arc<String> = Arc::new(function.into());
         let call = ast::Call {
             name: name.clone(),
             f_index: Cell::new(module.find_function(&name, 0)),
@@ -994,7 +994,7 @@ impl Runtime {
                 Ok(())
             }
             _ => return Err(module.error(call.source_range,
-                               &format!("Could not find function `{}`",fn_), self))
+                               &format!("Could not find function `{}`",function), self))
         }
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -976,6 +976,27 @@ impl Runtime {
             }
         }
     }
+    
+    pub fn call_str(&mut self, fn: &str, module: &Module) -> Result<(), String> {
+        use std::cell::Cell;
+
+        let name: Arc<String> = Arc::new(fn.into());
+        let call = ast::Call {
+            name: name.clone(),
+            f_index: Cell::new(module.find_function(&name, 0)),
+            args: vec![],
+            custom_source: None,
+            source_range: Range::empty(0),
+        };
+        match call.f_index.get() {
+            FnIndex::Loaded(f_index) => {
+                try!(self.call(&call, &module));
+                Ok(())
+            }
+            _ => return Err(module.error(call.source_range,
+                               &format!("Could not find function `{}`",fn), self))
+        }
+    }
 
     fn swizzle(&mut self, sw: &ast::Swizzle, module: &Module) -> Result<Flow, String> {
         let v = match try!(self.expression(&sw.expr, Side::Right, module)) {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -977,10 +977,10 @@ impl Runtime {
         }
     }
     
-    pub fn call_str(&mut self, fn: &str, module: &Module) -> Result<(), String> {
+    pub fn call_str(&mut self, fn_: &str, module: &Module) -> Result<(), String> {
         use std::cell::Cell;
 
-        let name: Arc<String> = Arc::new(fn.into());
+        let name: Arc<String> = Arc::new(fn_.into());
         let call = ast::Call {
             name: name.clone(),
             f_index: Cell::new(module.find_function(&name, 0)),
@@ -994,7 +994,7 @@ impl Runtime {
                 Ok(())
             }
             _ => return Err(module.error(call.source_range,
-                               &format!("Could not find function `{}`",fn), self))
+                               &format!("Could not find function `{}`",fn_), self))
         }
     }
 


### PR DESCRIPTION
Calling a function with a string name is something that would greatly allow for more Rust-Dyon interop, so here is a hacky try at it.