### PR TITLE
Change "max" and "min" intrinsic to use NaN for empty lists

### DIFF
--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -1970,14 +1970,10 @@ fn min(
     let v = rt.stack.pop().expect(TINVOTS);
     let v = match rt.resolve(&v) {
         &Variable::Array(ref arr) => {
-            if arr.len() == 0 {
-                return Err(module.error(call.args[0].source_range(),
-                    &format!("{}\nExpected non-empty array", rt.stack_trace()), rt));
-            }
-            let mut min: f64 = ::std::f64::MAX;
+            let mut min: f64 = ::std::f64::NAN;
             for v in &**arr {
                 if let &Variable::F64(val, _) = rt.resolve(v) {
-                    if val < min { min = val }
+                    if val < min || min.is_nan() { min = val }
                 }
             }
             min
@@ -2003,14 +1999,10 @@ fn max(
     let v = rt.stack.pop().expect(TINVOTS);
     let v = match rt.resolve(&v) {
         &Variable::Array(ref arr) => {
-            if arr.len() == 0 {
-                return Err(module.error(call.args[0].source_range(),
-                    &format!("{}\nExpected non-empty array", rt.stack_trace()), rt));
-            }
-            let mut max: f64 = ::std::f64::MIN;
+            let mut max: f64 = ::std::f64::NAN;
             for v in &**arr {
                 if let &Variable::F64(val, _) = rt.resolve(v) {
-                    if val > max { max = val }
+                    if val > max || max.is_nan() { max = val }
                 }
             }
             max

--- a/src/lib.dyon
+++ b/src/lib.dyon
@@ -193,9 +193,11 @@ fn is_err(var: res[any]) -> bool { ... }
 fn is_ok(var: res[any]) -> bool { ... }
 
 /// Returns smallest number in non-empty array.
+/// Returns NaN if array is empty.
 fn min(array: [f64]) -> f64 { ... }
 
 /// Returns highest number in non-empty array.
+/// Returns NaN if array is empty.
 fn max(array: [f64]) -> f64 { ... }
 
 /// Returns x component of 4D vector.
@@ -260,3 +262,6 @@ fn chars(text: str) -> [str] { ... }
 /// Returns seconds since last Unix Epoch.
 /// Returns `err(_)` if system clock is adjusted before Unix Epoch.
 fn now() -> f64 { ... }
+
+/// Returns `true` if number is NaN.
+fn is_nan(v: f64) -> bool { ... }


### PR DESCRIPTION
For consistency with the “max” and “min” loops.