### PR TITLE
Use lazy_static to parse language syntax once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ piston_meta = "0.26.1"
 range = "0.3.1"
 rand = "0.3.13"
 read_color = "0.1.0"
+lazy_static = "0.2.1"
 
 [dependencies.hyper]
 version = "0.9.7"


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/dyon/issues/363

Improves all benchmarks with roughly 2 ms, including "main" which now takes 0.4 ms.

```
Before:
test tests::bench_add           ... bench:  23,000,502 ns/iter (+/- 3,920,071)
test tests::bench_add_n         ... bench:  10,173,352 ns/iter (+/- 1,018,903)
test tests::bench_array         ... bench:  12,905,955 ns/iter (+/- 3,014,838)
test tests::bench_call          ... bench:  13,785,382 ns/iter (+/- 1,869,047)
test tests::bench_len           ... bench:   3,786,469 ns/iter (+/- 296,221)
test tests::bench_main          ... bench:   2,397,242 ns/iter (+/- 122,220) <-- 2.4 ms
test tests::bench_min           ... bench:  15,186,519 ns/iter (+/- 2,636,271)
test tests::bench_min_fn        ... bench:  44,881,395 ns/iter (+/- 4,509,293)
test tests::bench_n_body        ... bench:  63,363,341 ns/iter (+/- 6,056,302)
test tests::bench_object        ... bench:  20,318,807 ns/iter (+/- 1,814,959)
test tests::bench_primes        ... bench:  28,645,633 ns/iter (+/- 2,804,827)
test tests::bench_primes_trad   ... bench:  26,492,723 ns/iter (+/- 6,600,422)
test tests::bench_push_array    ... bench:  23,537,613 ns/iter (+/- 3,685,318)
test tests::bench_push_link     ... bench:  14,591,315 ns/iter (+/- 2,653,453)
test tests::bench_push_link_go  ... bench:  13,445,626 ns/iter (+/- 856,939)
test tests::bench_push_str      ... bench:  48,199,445 ns/iter (+/- 6,167,141)
test tests::bench_sum           ... bench:   6,404,971 ns/iter (+/- 484,571)
test tests::bench_threads_go    ... bench:  23,906,262 ns/iter (+/- 3,237,160)
test tests::bench_threads_no_go ... bench:  22,534,181 ns/iter (+/- 2,194,086)

After:
test tests::bench_add           ... bench:  21,793,057 ns/iter (+/- 3,414,723)
test tests::bench_add_n         ... bench:   8,412,286 ns/iter (+/- 941,225)
test tests::bench_array         ... bench:  10,872,121 ns/iter (+/- 1,105,821)
test tests::bench_call          ... bench:  11,948,541 ns/iter (+/- 2,428,421)
test tests::bench_len           ... bench:   1,827,033 ns/iter (+/- 217,537)
test tests::bench_main          ... bench:     397,917 ns/iter (+/- 40,496) <-- 0.4 ms
test tests::bench_min           ... bench:  12,861,460 ns/iter (+/- 1,891,274)
test tests::bench_min_fn        ... bench:  40,946,519 ns/iter (+/- 3,952,007)
test tests::bench_n_body        ... bench:  59,722,061 ns/iter (+/- 4,821,928)
test tests::bench_object        ... bench:  17,848,048 ns/iter (+/- 2,195,525)
test tests::bench_primes        ... bench:  26,253,924 ns/iter (+/- 4,960,100)
test tests::bench_primes_trad   ... bench:  23,185,951 ns/iter (+/- 2,494,492)
test tests::bench_push_array    ... bench:  20,127,759 ns/iter (+/- 2,174,437)
test tests::bench_push_link     ... bench:  12,155,305 ns/iter (+/- 2,149,276)
test tests::bench_push_link_go  ... bench:  11,259,453 ns/iter (+/- 1,233,067)
test tests::bench_push_str      ... bench:  45,411,572 ns/iter (+/- 5,554,306)
test tests::bench_sum           ... bench:   4,400,009 ns/iter (+/- 644,093)
test tests::bench_threads_go    ... bench:  22,144,941 ns/iter (+/- 2,088,511)
test tests::bench_threads_no_go ... bench:  20,773,956 ns/iter (+/- 2,429,051)
```