### PR TITLE
Added `sec[bool]` and `sec[f64]`

### DIFF
--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -153,6 +153,7 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
     "opt":"opt_any"
     ["res" ?w "[" ?w type:"res" ?w "]"]
     "res":"res_any"
+    ["sec" ?w "[" ?w {"bool":"sec_bool" "f64":"sec_f64"} ?w "]"]
     "[]":"arr_any"
     ["[" ?w type:"arr" ?w "]"]
     "{}":"obj_any"

--- a/source/syntax/lifetime_17.dyon
+++ b/source/syntax/lifetime_17.dyon
@@ -7,5 +7,5 @@ fn main() {
         item
     }
     println(max) // prints `4`
-    println(where(max)) // prints `[1, 1]`
+    println(where(max)) // prints `[1, 0]`
 }

--- a/source/syntax/lifetime_17.dyon
+++ b/source/syntax/lifetime_17.dyon
@@ -9,17 +9,3 @@ fn main() {
     println(max) // prints `4`
     println(where(max)) // prints `[1, 1]`
 }
-
-/*
-fn main() {
-    a := foo()
-    if a > 0 {
-        println(why(a > 0))
-    }
-    if (a ^ 1) > 0 {
-        println(where(a))
-    }
-}
-
-foo() = min i 3 { i+1 }
-*/

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -7,7 +7,7 @@ fn main() {
         item
     }
     println(max) // prints `4`
-    println(where(max)) // prints `[1, 1]`
+    println(where(max)) // prints `[1, 0]`
 }
 
 /*

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,25 +1,6 @@
 fn main() {
-    list := [[1, 2], [3, 4]]
-    item := 0
-    max := max i, j {
-        item = list[i][j]
-        if item == 4 { continue }
-        item
-    }
-    println(max) // prints `4`
-    println(where(max)) // prints `[1, 0]`
+    a := foo(explain_where(1, "hi"), 2)
+    println(why(a))
 }
 
-/*
-fn main() {
-    a := foo()
-    if a > 0 {
-        println(why(a > 0))
-    }
-    if (a ^ 1) > 0 {
-        println(where(a))
-    }
-}
-
-foo() = min i 3 { i+1 }
-*/
+foo(x: sec[f64], y) = x < y

--- a/source/typechk/secret.dyon
+++ b/source/typechk/secret.dyon
@@ -1,0 +1,8 @@
+fn main() {
+    a := explain_why(true, "hi")
+    foo(a)
+}
+
+fn foo(a: sec[bool]) {
+    println(a)
+}

--- a/source/typechk/secret_10.dyon
+++ b/source/typechk/secret_10.dyon
@@ -1,0 +1,6 @@
+fn main() {
+    a := 2
+    if a > 0 {
+        println(why(a > 0))
+    }
+}

--- a/source/typechk/secret_2.dyon
+++ b/source/typechk/secret_2.dyon
@@ -1,0 +1,8 @@
+fn main() {
+    a := true
+    foo(a)
+}
+
+fn foo(a: sec[bool]) {
+    println(a)
+}

--- a/source/typechk/secret_3.dyon
+++ b/source/typechk/secret_3.dyon
@@ -1,0 +1,5 @@
+fn main() {
+    a := true
+    b := why(a)
+    println(b)
+}

--- a/source/typechk/secret_4.dyon
+++ b/source/typechk/secret_4.dyon
@@ -1,0 +1,6 @@
+fn main() {
+    a := explain_why(true, "hi")
+    if a {
+        println(why(a))
+    }
+}

--- a/source/typechk/secret_5.dyon
+++ b/source/typechk/secret_5.dyon
@@ -1,0 +1,11 @@
+fn main() {
+    a := foo()
+    if a && true {
+        println(why(a))
+    }
+    if true && a {
+        println(why(a))
+    }
+}
+
+foo() = any i 3 { i == 2 }

--- a/source/typechk/secret_6.dyon
+++ b/source/typechk/secret_6.dyon
@@ -1,0 +1,11 @@
+fn main() {
+    a := foo()
+    if a || true {
+        println(why(a))
+    }
+    if true || a {
+        println(why(a))
+    }
+}
+
+foo() = any i 3 { i == 2 }

--- a/source/typechk/secret_7.dyon
+++ b/source/typechk/secret_7.dyon
@@ -1,0 +1,11 @@
+fn main() {
+    a := foo()
+    if a ^ true {
+        println(why(a))
+    }
+    if true ^ a {
+        println(why(a))
+    }
+}
+
+foo() = any i 3 { i == 2 }

--- a/source/typechk/secret_8.dyon
+++ b/source/typechk/secret_8.dyon
@@ -1,7 +1,7 @@
 fn main() {
     a := foo()
     if a > 0 {
-        println(why(a > 0))
+        println(where(a))
     }
     if (a ^ 1) > 0 {
         println(where(a))

--- a/source/typechk/secret_9.dyon
+++ b/source/typechk/secret_9.dyon
@@ -1,0 +1,8 @@
+fn main() {
+    a := foo()
+    if a > 0 {
+        println(why(a > 0))
+    }
+}
+
+foo() = min i 3 { i+1 }

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -213,23 +213,23 @@ pub fn standard(f: &mut Prelude) {
     sarg(f, "w", W, Type::Vec4, Type::F64);
     f.intrinsic(Arc::new("why".into()), WHY, Dfn {
         lts: vec![Lt::Default],
-        tys: vec![Type::Bool],
+        tys: vec![Type::Secret(Box::new(Type::Bool))],
         ret: Type::array()
     });
     f.intrinsic(Arc::new("where".into()), WHERE, Dfn {
         lts: vec![Lt::Default],
-        tys: vec![Type::F64],
+        tys: vec![Type::Secret(Box::new(Type::F64))],
         ret: Type::array()
     });
     f.intrinsic(Arc::new("explain_why".into()), EXPLAIN_WHY, Dfn {
         lts: vec![Lt::Default; 2],
         tys: vec![Type::Bool, Type::Any],
-        ret: Type::Bool
+        ret: Type::Secret(Box::new(Type::Bool))
     });
     f.intrinsic(Arc::new("explain_where".into()), EXPLAIN_WHERE, Dfn {
         lts: vec![Lt::Default; 2],
         tys: vec![Type::F64, Type::Any],
-        ret: Type::F64
+        ret: Type::Secret(Box::new(Type::F64))
     });
     sarg(f, "println", PRINTLN, Type::Any, Type::Void);
     sarg(f, "print", PRINT, Type::Any, Type::Void);

--- a/src/lib.dyon
+++ b/src/lib.dyon
@@ -1,18 +1,18 @@
 /// Returns an array of derived information for the truth value of `var`.
 /// This can be used with the value of `∃`/`any` and `∀`/`all` loops.
-fn why(var: bool) -> [any] { ... }
+fn why(var: sec[bool]) -> [any] { ... }
 
 /// Returns an array of derived information for the value of `var`.
 /// This can be used with the value of `min` and `max` loops.
-fn where(var: f64) -> [any] { ... }
+fn where(var: sec[f64]) -> [any] { ... }
 
 /// Adds message to derived information for the truth value of `var`.
 /// This can be used with the value of `∃`/`any` and `∀`/`all` loops.
-fn explain_why(var: bool, msg: any) -> bool { ... }
+fn explain_why(var: bool, msg: any) -> sec[bool] { ... }
 
 /// Adds message to derived information for the value of `var`.
 /// This can be used with the value of `min` and `max` loops.
-fn explain_where(var: f64, msg: any) -> f64 { ... }
+fn explain_where(var: f64, msg: any) -> sec[f64] { ... }
 
 /// Prints out variable to standard output, adding newline character.
 fn println(var: any) { ... }

--- a/src/lifetime/mod.rs
+++ b/src/lifetime/mod.rs
@@ -199,7 +199,7 @@ pub fn check(
                 if nodes[j].children.len() == 0 { continue; }
                 // Assign is inside an expression.
                 let j = nodes[j].children[0];
-                if nodes[j].kind != Kind::Assign { continue; }
+                if nodes[j].op != Some(AssignOp::Assign) { continue; }
                 let left = nodes[j].children[0];
                 let item = nodes[left].children[0];
                 if nodes[item].name() == nodes[i].name() {

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -55,7 +55,8 @@ impl Node {
 
     pub fn print(&self, nodes: &[Node], indent: u32) {
         for _ in 0..indent { print!(" ") }
-        println!("kind: {:?}, name: {:?}, type: {:?} {{", self.kind, self.name(), self.ty);
+        println!("kind: {:?}, name: {:?}, type: {:?}, decl: {:?} {{",
+            self.kind, self.name(), self.ty, self.declaration);
         for &c in &self.children {
             nodes[c].print(nodes, indent + 1);
         }

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -306,7 +306,6 @@ pub fn convert_meta_data(
                     Kind::Sift => Some(Type::array()),
                     Kind::Sum | Kind::Prod => Some(Type::F64),
                     Kind::Swizzle => Some(Type::F64),
-                    Kind::Compare => Some(Type::Bool),
                     Kind::Link => Some(Type::Link),
                     Kind::Any | Kind::All => Some(Type::Secret(Box::new(Type::Bool))),
                     Kind::Min | Kind::Max => Some(Type::Secret(Box::new(Type::F64))),

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -307,8 +307,8 @@ pub fn convert_meta_data(
                     Kind::Swizzle => Some(Type::F64),
                     Kind::Compare => Some(Type::Bool),
                     Kind::Link => Some(Type::Link),
-                    Kind::Any | Kind::All => Some(Type::Bool),
-                    Kind::Min | Kind::Max => Some(Type::F64),
+                    Kind::Any | Kind::All => Some(Type::Secret(Box::new(Type::Bool))),
+                    Kind::Min | Kind::Max => Some(Type::Secret(Box::new(Type::F64))),
                     Kind::For | Kind::ForN => Some(Type::Void),
                     _ => None
                 };

--- a/src/lifetime/typecheck.rs
+++ b/src/lifetime/typecheck.rs
@@ -133,7 +133,7 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude) -> Result<(), Range<String>
                                 let arg = nodes[decl].children[j];
                                 match (&expr_type, &nodes[arg].ty) {
                                     (&Some(ref ch_ty), &Some(ref arg_ty)) => {
-                                        if !ch_ty.goes_with(arg_ty) {
+                                        if !arg_ty.goes_with(ch_ty) {
                                             return Err(nodes[i].source.wrap(
                                                 format!("Type mismatch (#100):\n\
                                                     Expected `{}`, found `{}`",
@@ -146,7 +146,7 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude) -> Result<(), Range<String>
                                     nodes[parent].name().unwrap()) {
                                 let f = &prelude.list[f];
                                 if let Some(ref ty) = expr_type {
-                                    if !ty.goes_with(&f.tys[j]) {
+                                    if !f.tys[j].goes_with(ty) {
                                         return Err(nodes[i].source.wrap(
                                             format!("Type mismatch (#200):\n\
                                                 Expected `{}`, found `{}`",
@@ -285,7 +285,7 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude) -> Result<(), Range<String>
                                     // Infer return type of function.
                                     nodes[p].ty = Some(ty.clone());
                                 } else if let Some(ref fn_ty) = nodes[p].ty {
-                                    if !ty.goes_with(fn_ty) {
+                                    if !fn_ty.goes_with(&ty) {
                                         return Err(nodes[ch].source.wrap(
                                             format!("Type mismatch (#350):\n\
                                             Expected `{}`, found `{}`",

--- a/src/lifetime/typecheck.rs
+++ b/src/lifetime/typecheck.rs
@@ -255,8 +255,8 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude) -> Result<(), Range<String>
                     }
                 }
                 Kind::Return | Kind::Val | Kind::Expr | Kind::Cond |
-                Kind::Exp | Kind::Base | Kind::Right | Kind::ElseIfCond |
-                Kind::UnOp | Kind::Grab
+                Kind::Exp | Kind::Base | Kind::Left | Kind::Right |
+                Kind::ElseIfCond | Kind::UnOp | Kind::Grab
                  => {
                      // TODO: Report error for expected unary operator.
                     if nodes[i].children.len() == 0 { continue 'node; }
@@ -371,6 +371,27 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude) -> Result<(), Range<String>
                                              with `{}` and `{}`", base_ty.description(),
                                              exp_ty.description())));
                             }
+                        }
+                        _ => {}
+                    }
+                }
+                Kind::Compare => {
+                    let left = match nodes[i].find_child_by_kind(nodes, Kind::Left) {
+                        None => continue 'node,
+                        Some(x) => x
+                    };
+                    if nodes[left].item_ids() {
+                        continue 'node;
+                    }
+                    match &nodes[left].ty {
+                        &Some(Type::Any) => {
+                            this_ty = Some(Type::Any);
+                        }
+                        &Some(Type::Secret(_)) => {
+                            this_ty = Some(Type::Secret(Box::new(Type::Bool)));
+                        }
+                        &Some(_) => {
+                            this_ty = Some(Type::Bool);
                         }
                         _ => {}
                     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -180,6 +180,8 @@ fn test_typechk() {
     test_src("source/typechk/secret_6.dyon");
     test_src("source/typechk/secret_7.dyon");
     test_src("source/typechk/secret_8.dyon");
+    test_src("source/typechk/secret_9.dyon");
+    test_fail_src("source/typechk/secret_10.dyon");
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -171,6 +171,14 @@ fn test_typechk() {
     test_fail_src("source/typechk/grab.dyon");
     test_fail_src("source/typechk/grab_2.dyon");
     test_src("source/typechk/grab_3.dyon");
+    test_src("source/typechk/secret.dyon");
+    test_fail_src("source/typechk/secret_2.dyon");
+    test_fail_src("source/typechk/secret_3.dyon");
+    test_src("source/typechk/secret_4.dyon");
+    test_src("source/typechk/secret_5.dyon");
+    test_src("source/typechk/secret_6.dyon");
+    test_src("source/typechk/secret_7.dyon");
+    test_src("source/typechk/secret_8.dyon");
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -66,6 +66,7 @@ fn test_syntax() {
     test_fail_src("source/syntax/lifetime_14.dyon");
     test_src("source/syntax/lifetime_15.dyon");
     test_fail_src("source/syntax/lifetime_16.dyon");
+    test_src("source/syntax/lifetime_17.dyon");
     test_src("source/syntax/insert.dyon");
     test_src("source/syntax/named_call.dyon");
     test_src("source/syntax/max_min.dyon");


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/dyon/issues/367, fixes a bug in the lifetime checker https://github.com/PistonDevelopers/dyon/issues/374

This PR adds `sec[bool]` and `sec[f64]` types, which improves type safety for secrets and makes it easier to generate efficient Rust code from Dyon in the future.

### What is a secret?

A secret is a "hidden" array that is associated with a `bool` or `f64`. It is used to make problem solving easier by integrating this with mathematical loops in Dyon.

For example, to look up where a maximum value comes from:

```rust
fn main() {
    list := [[1, 2], [3, 4]]
    item := 0
    max := max i, j {
        item = list[i][j]
        if item == 4 { continue }
        item
    }
    println(max) // prints `4`
    println(where(max)) // prints `[1, 0]`
}
```

Dyon uses index notation for mathematical loops, such that the argument of `any`/`all`/`min`/`max` compositions of loops can be propagated as a secret.