### PR TITLE
Use direct external reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1827,7 +1827,7 @@ impl Call {
                     stack.push(Some(Arc::new("return".into())));
                 }
             }
-            FnIndex::External(_) => {
+            FnIndex::ExternalVoid(_) | FnIndex::ExternalReturn(_) => {
                 // Don't push return since last value in block
                 // is used as return value.
             }

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -1734,7 +1734,8 @@ fn _call(
                         module.error(call.args[2].source_range(),
                         &format!("{}\n{}", err, rt.stack_trace()), rt)));
                 }
-                FnIndex::Intrinsic(_) | FnIndex::None | FnIndex::External(_) =>
+                FnIndex::Intrinsic(_) | FnIndex::None |
+                FnIndex::ExternalVoid(_) | FnIndex::ExternalReturn(_) =>
                     return Err(module.error(
                             call.args[1].source_range(),
                             &format!(
@@ -1814,7 +1815,8 @@ fn call_ret(
                         module.error(call.args[2].source_range(),
                         &format!("{}\n{}", err, rt.stack_trace()), rt)));
                 }
-                FnIndex::Intrinsic(_) | FnIndex::None | FnIndex::External(_) =>
+                FnIndex::Intrinsic(_) | FnIndex::None |
+                FnIndex::ExternalVoid(_) | FnIndex::ExternalReturn(_) =>
                     return Err(module.error(
                         call.args[1].source_range(),
                         &format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ impl Clone for FnExternalRef {
 
 impl fmt::Debug for FnExternalRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "FnRef")
+        write!(f, "FnExternalRef")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,24 @@ pub enum FnIndex {
     Intrinsic(usize),
     /// Relative to function you call from.
     Loaded(isize),
-    External(usize),
+    ExternalVoid(FnExternalRef),
+    ExternalReturn(FnExternalRef),
+}
+
+/// Used to store direct reference to external function.
+#[derive(Copy)]
+pub struct FnExternalRef(pub fn(&mut Runtime) -> Result<(), String>);
+
+impl Clone for FnExternalRef {
+    fn clone(&self) -> FnExternalRef {
+        *self
+    }
+}
+
+impl fmt::Debug for FnExternalRef {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "FnRef")
+    }
 }
 
 pub struct FnExternal {
@@ -265,9 +282,13 @@ impl Module {
                 return FnIndex::Loaded(i as isize - relative as isize);
             }
         }
-        for (i, f) in self.ext_prelude.iter().enumerate().rev() {
+        for f in self.ext_prelude.iter().rev() {
             if &f.name == name {
-                return FnIndex::External(i);
+                return if f.p.returns() {
+                    FnIndex::ExternalReturn(FnExternalRef(f.f))
+                } else {
+                    FnIndex::ExternalVoid(FnExternalRef(f.f))
+                };
             }
         }
         match self.intrinsics.get(name) {


### PR DESCRIPTION
- Bumped to 0.11.0

This fixes a bug when importing external functions from another module that is created by an external function, e.g:

```rust
fn main() {
    window := load_window()
    image := load_image()
    input := load_input()
    draw := unwrap(load(
        source: "src/draw.dyon",
        imports: [image] // `draw` imports external functions from `image`
    ))
    main := unwrap(load(
        source: "src/programs/rectangle.dyon",
        imports: [window, draw, input] // external offset mismatch, fixed by direct reference
    ))
    call(main, "main", [])
}
```