### PR TITLE
Remove unreachable expression

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -807,9 +807,6 @@ impl Runtime {
                 return Ok((b, Flow::Continue))
             }
         }
-
-        return Err(module.error(call.source_range,
-            &format!("{}\nUnknown closure `{}`", self.stack_trace(), call.item.name), self))
     }
 
     pub fn call(


### PR DESCRIPTION
This line is unreachable since every branch of  match return.