### PR TITLE
Fixed some bugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.15.5"
+version = "0.15.6"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,5 +1,9 @@
 fn main() {
-    println(foo())
+    list := [1, 2, 3]
+    println(link i {
+        id := (i+1)
+        id
+        id2 := (i+2)
+        list[i] > 1
+    })
 }
-
-foo() = link i 3 {"hi "i"\n"}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1011,8 +1011,8 @@ impl Link {
         let st = stack.len();
         for expr in &self.items {
             expr.resolve_locals(relative, stack, closure_stack, module);
-            stack.truncate(st);
         }
+        stack.truncate(st);
     }
 }
 

--- a/src/lifetime/typecheck.rs
+++ b/src/lifetime/typecheck.rs
@@ -217,7 +217,7 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude) -> Result<(), Range<String>
                             Kind::Sum | Kind::Min | Kind::Max |
                             Kind::Any | Kind::All | Kind::Sift |
                             Kind::Vec4UnLoop |
-                            Kind::ForN => {
+                            Kind::ForN | Kind::LinkFor => {
                                 if nodes[i].try {
                                     return Err(nodes[i].source.wrap(
                                         "Type mismatch (#300):\n\


### PR DESCRIPTION
- Bumped to 0.15.6
- Resolve locals correctly in link item by not truncating stack after
declarations inside body
- Infer type of index for `link` loop as f64