### PR TITLE
Rename "load_syntax_data" to "parse_syntax_data"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.15.6"
+version = "0.15.7"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/src/intrinsics/meta.rs
+++ b/src/intrinsics/meta.rs
@@ -2,12 +2,17 @@ use std::sync::Arc;
 use std::io::{self, Read};
 use std::fs::File;
 use std::error::Error;
-use piston_meta::*;
+use piston_meta::{
+    parse_errstr,
+    syntax_errstr,
+    MetaData,
+    Syntax,
+};
 use super::io::io_error;
 
 use Variable;
 
-pub fn load_syntax_data(rules: &Syntax, file: &str, d: &str) -> Result<Vec<Variable>, String> {
+pub fn parse_syntax_data(rules: &Syntax, file: &str, d: &str) -> Result<Vec<Variable>, String> {
     let mut tokens = vec![];
     try!(parse_errstr(&rules, &d, &mut tokens).map_err(|err|
         format!("When parsing data in `{}`:\n{}", file, err)));
@@ -54,7 +59,7 @@ pub fn load_syntax_data(rules: &Syntax, file: &str, d: &str) -> Result<Vec<Varia
 fn load_metarules_data(meta: &str, s: &str, file: &str, d: &str) -> Result<Vec<Variable>, String> {
     let rules = try!(syntax_errstr(&s).map_err(|err|
         format!("When parsing meta syntax in `{}`:\n{}", meta, err)));
-    load_syntax_data(&rules, file, d)
+    parse_syntax_data(&rules, file, d)
 }
 
 /// Loads a file using a meta file as syntax.

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -2388,7 +2388,7 @@ fn meta__syntax_in_string(
         x => return Err(module.error(call.args[0].source_range(),
                         &rt.expected(x, "Syntax"), rt))
     };
-    let res = meta::load_syntax_data(match syntax.lock().unwrap()
+    let res = meta::parse_syntax_data(match syntax.lock().unwrap()
         .downcast_ref::<Arc<Syntax>>() {
         Some(s) => s,
         None => return Err(module.error(call.args[0].source_range(),


### PR DESCRIPTION
Avoid collision with “piston_meta::load_syntax_data”.

- Bumped to 0.15.7
- Removed glob import