### PR TITLE
Fixed bug when variable starts with "true"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -78,7 +78,7 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
            ?[, arg_expr:"z" ?[, arg_expr:"w"]] ?, ?w ")"]
 19 color = ["#" .._seps!:"color"]
 20 text = .t?:"text"
-21 bool = {"true":"bool" "false":!"bool"}
+21 bool = [{"true":"bool" "false":!"bool"} !.._seps!]
 22 unop_not = [{"!":"!" "¬":"!"} ?w lexpr:"expr"]
 23 unop_neg = ["-":"-" ?w mul_expr:"expr"]
 24 norm = ["|" ?w expr:"expr" ?w "|"]

--- a/source/syntax/start_true.dyon
+++ b/source/syntax/start_true.dyon
@@ -1,0 +1,5 @@
+fn main() {
+    a := 3
+    true_a := 4
+    println(a + true_a)
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -113,6 +113,7 @@ fn test_syntax() {
     test_src("source/syntax/closure_6.dyon");
     test_src("source/syntax/or.dyon");
     test_src("source/syntax/try_expr.dyon");
+    test_src("source/syntax/start_true.dyon");
 }
 
 #[test]


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/dyon/issues/443

- Bumped to 0.21.1

Do not match boolean rule if there is a non-whitespace characters that
is not in the separator string.