### PR TITLE
Made HTTP support opt-out by Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.21.1"
+version = "0.22.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"
@@ -21,7 +21,9 @@ lazy_static = "0.2.1"
 [dependencies.hyper]
 version = "0.9.7"
 default-features = false
+optional = true
 
 [features]
-default = ["debug_resolve"]
+default = ["debug_resolve", "http"]
 debug_resolve = []
+http = ["hyper"]

--- a/src/lib.dyon
+++ b/src/lib.dyon
@@ -281,6 +281,10 @@ fn save__string_file(string: str, file: str) -> res[str] { ... }
 /// Returns `ok(text)` if the loading succeeded.
 fn load_string__file(file: str) -> res[str] { ... }
 
+/// Loads a string from url.
+/// Returns `ok(text)` if the loading succeeded.
+fn load_string__url(url: str) -> res[str] { ... }
+
 /// Waits for thread to finish and returns the result.
 fn join__thread(t: thr[any]) -> res[any] { ... }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate rand;
 extern crate range;
 extern crate read_color;
 extern crate read_token;
+#[cfg(feature = "http")]
 extern crate hyper;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/dyon/issues/442

- Added “load_string__url” intrinsic
- Bumped to 0.22.0

Adds a default feature flag for HTTP support.