### PR TITLE
Optional namespaces with shared aliases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -6,27 +6,34 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
 201 comment = {multi_line_comment ["//" ..."\n"?]}
 202 w = .r!({.w! comment})
 
-0 fn = {
+0 ns = ["ns" .w! .s!("::" .._seps!:"name")]
+1 uses = .l({[.w? use:"use"] comment})
+2 use = ["use" .w! .s!(["::" !"{"] .._seps!:"name")
+    ?["::" .w? "{" .w? .s?.(,
+        [.._seps!:"use_fn" ?[.w! "as" .w! .._seps!:"use_fn_alias"]]
+    ) .w? "}"]
+    .w! "as" .w! .._seps!:"alias"]
+3 fn = {
     ["fn" .w! .."("!:"name" ?w "(" ?w args ?w ")" ?w ?currents ?w {
             ["->":"returns" ?w ?type:"ret_type"]
             !"->":!"returns"
         } ?w block:"block"]
     [.."("!:"name" ?w "(" ?w args ?w ")" ?w ?currents ?w "=" ?w expr:"expr"]
 }
-1 args = .s?.(, arg:"arg")
-2 arg = [?"mut":"mut" ?w .._seps!:"name" ?[?w ":" ?w
+4 args = .s?.(, arg:"arg")
+5 arg = [?"mut":"mut" ?w .._seps!:"name" ?[?w ":" ?w
          ?["'" ?w .._seps!:"lifetime"] ?w ?type:"type"]]
-3 imm_arg = [!"mut " .._seps!:"name" ?[?w ":" ?w !"'" ?type:"type"]]
-4 closure = ["\\(" ?w .s?.(, imm_arg:"arg") ?w ")" ?w ?currents
+6 imm_arg = [!"mut " .._seps!:"name" ?[?w ":" ?w !"'" ?type:"type"]]
+7 closure = ["\\(" ?w .s?.(, imm_arg:"arg") ?w ")" ?w ?currents
              ?w "=" ?w expr:"expr"]
-5 call_closure = ["\\" item:"item" ?w "(" .s?.(, arg_expr:"call_arg") ?w ")"]
-6 named_call_closure = ["\\" item:"item" ?w "(" ?w
+8 call_closure = ["\\" item:"item" ?w "(" .s?.(, arg_expr:"call_arg") ?w ")"]
+9 named_call_closure = ["\\" item:"item" ?w "(" ?w
     .s?.(, [.._seps!:"word" ?w ":" ?w arg_expr:"call_arg" ?w]) ")"]
-7 currents = ["~" ?w .s!.(, current:"current")]
-8 current = [?"mut":"mut" ?w .._seps!:"name" ?[?w ":" ?w type:"type"]]
+10 currents = ["~" ?w .s!.(, current:"current")]
+11 current = [?"mut":"mut" ?w .._seps!:"name" ?[?w ":" ?w type:"type"]]
 // Support both multi-line expressions and single line.
-9 block = ["{" ?w {.l([?w expr:"expr" ?w]) [?w expr:"expr"]} ?w "}"]
-10 expr = [{
+12 block = ["{" ?w {.l([?w expr:"expr" ?w]) [?w expr:"expr"]} ?w "}"]
+13 expr = [{
     closure:"closure"
     object:"object"
     arr
@@ -46,7 +53,7 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
     items
 } try]
 // Interprets "return" as variable, does not expect loops or assignment.
-11 arg_expr = {
+14 arg_expr = {
     ["mut":"mut" ?w item:"item"]
     swizzle:"swizzle"
     [{
@@ -61,7 +68,7 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
         items
     } try]
 }
-12 lexpr = [{
+15 lexpr = [{
     closure:"closure"
     object:"object"
     arr
@@ -69,55 +76,56 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
     block:"block"
     items
 } try]
-13 object = ["{" ?w .s?.(, key_value:"key_value") ?w "}"]
-14 array = ["[" ?w .s?.(, expr:"array_item") ?w "]"]
-15 array_fill = ["[" ?w expr:"fill" ?w ";" ?w expr:"n" ?w "]"]
-16 key_value = [{.t?:"key" .._seps!:"key"} ?w ":" ?w expr:"val"]
-17 num = .$_:"num"
-18 vec4 = ["(" ?w arg_expr:"x" , ?arg_expr:"y"
+16 object = ["{" ?w .s?.(, key_value:"key_value") ?w "}"]
+17 array = ["[" ?w .s?.(, expr:"array_item") ?w "]"]
+18 array_fill = ["[" ?w expr:"fill" ?w ";" ?w expr:"n" ?w "]"]
+19 key_value = [{.t?:"key" .._seps!:"key"} ?w ":" ?w expr:"val"]
+20 num = .$_:"num"
+21 vec4 = ["(" ?w arg_expr:"x" , ?arg_expr:"y"
            ?[, arg_expr:"z" ?[, arg_expr:"w"]] ?, ?w ")"]
-19 color = ["#" .._seps!:"color"]
-20 text = .t?:"text"
-21 bool = [{"true":"bool" "false":!"bool"} !.._seps!]
-22 unop_not = [{"!":"!" "¬":"!"} ?w lexpr:"expr"]
-23 unop_neg = ["-":"-" ?w mul_expr:"expr"]
-24 norm = ["|" ?w expr:"expr" ?w "|"]
-25 item = [?"~":"current" ?w .._seps!:"name" ?[?w "?":"try_item"]
+22 color = ["#" .._seps!:"color"]
+23 text = .t?:"text"
+24 bool = [{"true":"bool" "false":!"bool"} !.._seps!]
+25 unop_not = [{"!":"!" "¬":"!"} ?w lexpr:"expr"]
+26 unop_neg = ["-":"-" ?w mul_expr:"expr"]
+27 norm = ["|" ?w expr:"expr" ?w "|"]
+28 item = [?"~":"current" ?w .._seps!:"name" ?[?w "?":"try_item"]
     ?item_extra:"item_extra"]
-26 item_extra = .r!([{
+29 item_extra = .r!([{
            [?w "[" ?w {.t?:"id" .$_:"id" expr:"id"} ?w "]"]
            [?w "." ?w .._seps!:"id"]} ?[?w "?":"try_id"]])
-27 link = ["link" ?w "{" ?w link_body "}"]
-28 link_body = .s?.(?w expr:"link_item")
+30 link = ["link" ?w "{" ?w link_body "}"]
+31 link_body = .s?.(?w expr:"link_item")
 // Generate link block for body.
-29 link_for = [label "link" .w! .s!.(, [.._seps!:"name" ?w
+32 link_for = [label "link" .w! .s!.(, [.._seps!:"name" ?w
     ?{
         ["[" ?w expr:"start" , expr:"end" ?w ")"]
         [!"{" expr:"end"]
     }]) ?w "{" ?w link_body_block:"block" "}"]
-30 link_body_block = link_body_expr:"expr"
-31 link_body_expr = link_body:"link"
-32 for = [label "for" .w!
+33 link_body_block = link_body_expr:"expr"
+34 link_body_expr = link_body:"link"
+35 for = [label "for" .w!
     expr:"init" ?w ";" ?w
     expr:"cond" ?w ";" ?w
     expr:"step" ?w block:"block"]
-33 for_n = [label "for" short_body]
-34 loop = [label "loop" .w!  block:"block"]
-35 break = ["break" ?w ?["'" .._seps!:"label"]]
-36 continue = ["continue" ?w ?["'" .._seps!:"label"]]
-37 if = ["if" .w! expr:"cond" ?w block:"true_block"
+36 for_n = [label "for" short_body]
+37 loop = [label "loop" .w!  block:"block"]
+38 break = ["break" ?w ?["'" .._seps!:"label"]]
+39 continue = ["continue" ?w ?["'" .._seps!:"label"]]
+40 if = ["if" .w! expr:"cond" ?w block:"true_block"
          .r?([?w "else" w "if" ?w expr:"else_if_cond" ?w block:"else_if_block"])
          ?[?w "else" ?w block:"else_block"]]
-38 call = [.._seps!:"name" wn "(" ?w .s?.(, arg_expr:"call_arg") ?w ")"]
-39 named_call = [.._seps!:"word" wn "(" ?w
+41 call = [?[.._seps!:"alias" "::"] .._seps!:"name" wn "(" ?w
+    .s?.(, arg_expr:"call_arg") ?w ")"]
+42 named_call = [?[.._seps!:"alias" "::"] .._seps!:"word" wn "(" ?w
     .s?.(, [.._seps!:"word" ?w ":" ?w arg_expr:"call_arg" ?w]) ")"]
-40 go = ["go " ?w {call:"call" named_call:"named_call"}]
-41 assign = [lexpr:"left" ?w assign_op ?w expr:"right"]
-42 assign_op = {":=":":=" "=":"=" "+=":"+=" "-=":"-=" "*=":"*=" "/=":"/=" "%=":"%="}
-43 compare = [lexpr:"left" ?w compare_op ?w expr:"right"]
-44 compare_op = {"==":"==" "!=":"!=" "¬=":"!=" "<=":"<=" "<":"<" ">=":">=" ">":">"}
-45 grab = ["grab" ?[w "'" .$:"grab_level"] w expr:"expr"]
-46 try_expr = ["try" w expr:"expr"]
+43 go = ["go " ?w {call:"call" named_call:"named_call"}]
+44 assign = [lexpr:"left" ?w assign_op ?w expr:"right"]
+45 assign_op = {":=":":=" "=":"=" "+=":"+=" "-=":"-=" "*=":"*=" "/=":"/=" "%=":"%="}
+46 compare = [lexpr:"left" ?w compare_op ?w expr:"right"]
+47 compare_op = {"==":"==" "!=":"!=" "¬=":"!=" "<=":"<=" "<":"<" ">=":">=" ">":">"}
+48 grab = ["grab" ?[w "'" .$:"grab_level"] w expr:"expr"]
+49 try_expr = ["try" w expr:"expr"]
 
 50 label = ?["'" .._seps!:"label" ?w ":" ?w]
 51 short_body = [.w! .s!.(, [.._seps!:"name" ?w
@@ -193,4 +201,4 @@ _seps: "(){}[],.:;=<>*·+-/%^?~|&∧∨!¬∑∃∀\n\"\\"
 107 mul_expr = {mul:"mul"}
 108 add = .s!({+ -} mul_expr:"expr")
 
-1000 document = .l({[.w? fn:"fn"] comment})
+1000 document = [?ns:"ns" ?w ?uses:"uses" ?w .l({[.w? fn:"fn"] comment})]

--- a/source/namespace/graphics.dyon
+++ b/source/namespace/graphics.dyon
@@ -1,0 +1,13 @@
+ns graphics
+
+fn line(a: vec4, b: vec4) -> {} {
+    return {
+        from: clone(a),
+        to: clone(b),
+    }
+}
+
+fn add(a: f64, b: f64) -> f64 {
+    println("boo")
+    return a + b
+}

--- a/source/namespace/loader.dyon
+++ b/source/namespace/loader.dyon
@@ -1,0 +1,11 @@
+ns loader
+
+fn main() {
+    math := unwrap(load("source/namespace/math.dyon"))
+    graphics := unwrap(load("source/namespace/graphics.dyon"))
+    main := unwrap(load(
+        source: "source/namespace/main.dyon",
+        imports: [math, graphics]
+    ))
+    call(main, "main", [])
+}

--- a/source/namespace/main.dyon
+++ b/source/namespace/main.dyon
@@ -1,7 +1,9 @@
 ns program
 
-use math::{add} as m
+use math::algebra::{add} as m
+use graphics::{line} as m
 
 fn main() {
     println(m::add(1, 2))
+    println(m::line((0, 0), (1, 1)))
 }

--- a/source/namespace/main.dyon
+++ b/source/namespace/main.dyon
@@ -1,9 +1,11 @@
 ns program
 
-use math::algebra::{add} as m
+use math::algebra::{add as plus} as m
 use graphics::{line} as m
 
 fn main() {
-    println(m::add(1, 2))
+    bar(m::plus(1, 2))
     println(m::line((0, 0), (1, 1)))
 }
+
+fn bar(a: f64) {}

--- a/source/namespace/main.dyon
+++ b/source/namespace/main.dyon
@@ -1,0 +1,7 @@
+ns program
+
+use math::{add} as m
+
+fn main() {
+    println(m::add(1, 2))
+}

--- a/source/namespace/math.dyon
+++ b/source/namespace/math.dyon
@@ -1,5 +1,9 @@
-ns math
+ns math::algebra
 
 fn add(a: f64, b: f64) -> f64 {
     return a + b
+}
+
+fn sub(a: f64, b: f64) -> f64 {
+    return a - b
 }

--- a/source/namespace/math.dyon
+++ b/source/namespace/math.dyon
@@ -1,0 +1,5 @@
+ns math
+
+fn add(a: f64, b: f64) -> f64 {
+    return a + b
+}

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,8 +1,9 @@
 fn main() {
     math := unwrap(load("source/namespace/math.dyon"))
+    graphics := unwrap(load("source/namespace/graphics.dyon"))
     main := unwrap(load(
         source: "source/namespace/main.dyon",
-        imports: [math]
+        imports: [math, graphics]
     ))
     call(main, "main", [])
 }

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,6 +1,8 @@
 fn main() {
-    fail := unwrap(load("source/data/fail.dyon"))
-    success := unwrap(load("source/data/success.dyon"))
-    call(fail, "main", [])
-    call(success, "main", [])
+    math := unwrap(load("source/namespace/math.dyon"))
+    main := unwrap(load(
+        source: "source/namespace/main.dyon",
+        imports: [math]
+    ))
+    call(main, "main", [])
 }

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,9 +1,4 @@
 fn main() {
-    math := unwrap(load("source/namespace/math.dyon"))
-    graphics := unwrap(load("source/namespace/graphics.dyon"))
-    main := unwrap(load(
-        source: "source/namespace/main.dyon",
-        imports: [math, graphics]
-    ))
-    call(main, "main", [])
+    loader := unwrap(load("source/namespace/loader.dyon"))
+    call(loader, "main", [])
 }

--- a/src/ast/infer_len.rs
+++ b/src/ast/infer_len.rs
@@ -19,6 +19,7 @@ pub fn infer(block: &Block, name: &str) -> Option<Expression> {
     let res = list.map(|item| {
         let source_range = item.source_range;
         Expression::Call(Call {
+            alias: None,
             name: Arc::new("len".into()),
             f_index: Cell::new(FnIndex::None),
             args: vec![

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -284,6 +284,7 @@ fn number_call(call_expr: &Call, name: &Arc<String>, val: f64) -> Call {
         new_args.push(number(arg, name, val));
     }
     Call {
+        alias: call_expr.alias.clone(),
         name: call_expr.name.clone(),
         args: new_args,
         f_index: call_expr.f_index.clone(),

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -182,6 +182,7 @@ pub fn grab_expr(
             let call = &go.call;
             Ok((Grabbed::Expression(E::Go(Box::new(ast::Go {
                 call: ast::Call {
+                    alias: call.alias.clone(),
                     name: call.name.clone(),
                     args: {
                         let mut new_args = vec![];
@@ -202,6 +203,7 @@ pub fn grab_expr(
         }
         &E::Call(ref call) => {
             Ok((Grabbed::Expression(E::Call(ast::Call {
+                alias: call.alias.clone(),
                 name: call.name.clone(),
                 args: {
                     let mut new_args = vec![];

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -1858,6 +1858,7 @@ fn _call(
                                 fn_name), rt))
             }
             let call = ast::Call {
+                alias: None,
                 name: fn_name.clone(),
                 f_index: Cell::new(f_index),
                 args: args.iter().map(|arg|
@@ -1939,6 +1940,7 @@ fn call_ret(
                             fn_name), rt))
             }
             let call = ast::Call {
+                alias: None,
                 name: fn_name.clone(),
                 f_index: Cell::new(f_index),
                 args: args.iter().map(|arg|

--- a/src/lifetime/kind.rs
+++ b/src/lifetime/kind.rs
@@ -1,6 +1,9 @@
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {
+    Ns,
+    Uses,
+    Use,
     Fn,
     Arg,
     Current,
@@ -88,6 +91,9 @@ pub enum Kind {
 impl Kind {
     pub fn new(name: &str) -> Option<Kind> {
         Some(match name {
+            "ns" => Kind::Ns,
+            "uses" => Kind::Uses,
+            "use" => Kind::Use,
             "fn" => Kind::Fn,
             "arg" => Kind::Arg,
             "current" => Kind::Current,

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -13,6 +13,8 @@ use Type;
 pub struct Node {
     /// The kind of node.
     pub kind: Kind,
+    /// The namespace alias.
+    pub alias: Option<Arc<String>>,
     /// The names associated with a node.
     pub names: Vec<Arc<String>>,
     /// The type.
@@ -323,6 +325,7 @@ pub fn convert_meta_data(
                 parents.push(nodes.len());
                 nodes.push(Node {
                     kind: kind,
+                    alias: None,
                     names: vec![],
                     ty: ty,
                     mutable: false,
@@ -357,6 +360,10 @@ pub fn convert_meta_data(
             }
             MetaData::String(ref n, ref val) => {
                 match &***n {
+                    "alias" => {
+                        let i = *parents.last().unwrap();
+                        nodes[i].alias = Some(val.clone());
+                    }
                     "name" => {
                         let i = *parents.last().unwrap();
                         nodes[i].names.push(val.clone());

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -58,26 +58,30 @@ impl Dfn {
 pub struct Prelude {
     pub functions: HashMap<Arc<String>, usize>,
     pub list: Vec<Dfn>,
+    pub namespaces: Vec<(Arc<Vec<Arc<String>>>, Arc<String>)>,
 }
 
 impl Prelude {
-    pub fn insert(&mut self, name: Arc<String>, f: Dfn) {
+    pub fn insert(&mut self, namespace: Arc<Vec<Arc<String>>>, name: Arc<String>, f: Dfn) {
         let n = self.list.len();
-        self.functions.insert(name, n);
+        self.functions.insert(name.clone(), n);
         self.list.push(f);
+        self.namespaces.push((namespace, name));
     }
 
     pub fn intrinsic(&mut self, name: Arc<String>, index: usize, f: Dfn) {
         let n = self.list.len();
         assert!(n == index, "{}", name);
-        self.functions.insert(name, n);
+        self.functions.insert(name.clone(), n);
         self.list.push(f);
+        self.namespaces.push((Arc::new(vec![]), name));
     }
 
     pub fn new() -> Prelude {
         Prelude {
             functions: HashMap::new(),
-            list: vec![]
+            list: vec![],
+            namespaces: vec![],
         }
     }
 
@@ -91,10 +95,10 @@ impl Prelude {
         let mut prelude = Prelude::new();
         intrinsics::standard(&mut prelude);
         for f in &*module.ext_prelude {
-            prelude.insert(f.name.clone(), f.p.clone());
+            prelude.insert(Arc::new(vec![]), f.name.clone(), f.p.clone());
         }
         for f in &module.functions {
-            prelude.insert(f.name.clone(), Dfn::new(f));
+            prelude.insert(f.namespace.clone(), f.name.clone(), Dfn::new(f));
         }
         prelude
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -579,6 +579,7 @@ impl Runtime {
 
         let name: Arc<String> = Arc::new("main".into());
         let call = ast::Call {
+            alias: None,
             name: name.clone(),
             f_index: Cell::new(module.find_function(&name, 0)),
             args: vec![],
@@ -636,6 +637,7 @@ impl Runtime {
         let mut stack = vec![];
         let relative = self.call_stack.last().map(|c| c.index).unwrap();
         let mut fake_call = ast::Call {
+            alias: go.call.alias.clone(),
             name: go.call.name.clone(),
             f_index: Cell::new(module.find_function(&go.call.name, relative)),
             args: Vec::with_capacity(n),
@@ -1041,6 +1043,7 @@ impl Runtime {
         match module.find_function(&name, 0) {
             FnIndex::Loaded(f_index) => {
                 let call = ast::Call {
+                    alias: None,
                     name: name.clone(),
                     f_index: Cell::new(FnIndex::Loaded(f_index)),
                     args: args.iter()


### PR DESCRIPTION
For design, see https://github.com/PistonDevelopers/dyon/issues/434

- Published 0.24.0

This PR adds optional namespaces to Dyon as a way to organize code and avoid name collisions. At the moment this is only supported for loaded modules, not external functions.

### How dynamic modules work in Dyon

Dyon uses dynamic modules to organize code. In order for one module to depend on another, you write a loader script, like this:

```rust
fn main() {
    graphics := unwrap(load("graphics.dyon"))
    program := unwrap(load(source: "main.dyon", imports: [graphics]))
    call(program, "main", [])
}
```

This puts the functions declared in `graphics` in the prelude of the module `program`. You do not have to write any imports, you just call them.

```
fn main() {
    render() // the `render` function is put in the prelude by loader script
}
```

This design makes it easy to refactor code, because you can simply copy and paste a function to another module and expect it to work. Since module loading is controlled by the loader script, you can update parts of the program while running.

### How optional namespaces work

An optional namespace can be declared at the beginning of the file with the `ns` keyword:

```rust
ns graphics

fn render() { ... }
```

This puts all functions in this file in an extra namespace `graphics`.

You can also uses nested namespaces, like this:

```rust
ns graphics::animation::skeleton

fn render() { ... }
```

To use a namespace, you write `use` after the line with `ns` and give it an alias:

```rust
ns program

use graphics as gfx

fn main() {
    gfx::render() // call the `render` function in the namespace alias `g`
}
```

All `use` statements requires an alias. This is designed to make refactoring easier, because you can just change the top of the file instead of going through the whole code.

You can also share an alias between multiple imports, like this:

```rust
ns program

use game_logic as game
use graphics as game
use window as game

fn main() {
     loop {
         if game::closed() {break}
         // update game logic.
         game::update()
         // render to screen.
         game::render()
     }
}
```

Notice that you still can use the default namespace, so without any name collisions you can just write like this:

```rust
ns program

fn main() {
     loop {
         if closed() {break}
         // update game logic.
         update()
         // render to screen.
         render()
     }
}
```

### Import specific functions while excluding others

```rust
ns program

// Only use `render` and `swap_buffer` with the `game` namespace alias
use graphics::{render, swap_buffer} as game

fn main() {
    game::render()
    game::swap_buffer()
}
```

When importing specific functions, they will shadow any function in global import:

```rust
ns program

use graphics::{render} as game
use game_logic as game

fn main() {
    game::render() // always call `graphics::render`, even if `game_logic` adds a `render`.
}
```

### Rename a specific function

```rust
ns program

use graphics::{render as present} as game

fn main() {
    game::present() // `render` is now called `present`
}
```