### PR TITLE
Fixed bug in lifetime checker when "push_ref" at end of block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.24.1"
+version = "0.24.2"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/source/syntax/push_ref.dyon
+++ b/source/syntax/push_ref.dyon
@@ -1,0 +1,8 @@
+fn main() {
+    a := []
+    b := foo(a)
+    c := 1
+    push_ref(mut b, c)
+}
+
+foo(x: 'return) = x

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -126,9 +126,7 @@ impl Node {
             // Intrinsic functions copies argument constraints to the call.
             if self.kind == Kind::Call && self.lts.len() > 0 {
                 let mut returns_static = true;
-                'args: for (_, lt) in self.children.iter().map(|&i| &nodes[i])
-                        .filter(|&n| n.kind == Kind::CallArg)
-                        .zip(self.lts.iter()) {
+                'args: for lt in self.lts.iter() {
                     let mut lt = *lt;
                     loop {
                         match lt {
@@ -139,8 +137,8 @@ impl Node {
                                 returns_static = false;
                                 break 'args;
                             }
-                            x => {
-                                lt = x;
+                            Lt::Arg(x) => {
+                                lt = self.lts[x];
                                 continue;
                             }
                         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -114,6 +114,7 @@ fn test_syntax() {
     test_src("source/syntax/or.dyon");
     test_src("source/syntax/try_expr.dyon");
     test_src("source/syntax/start_true.dyon");
+    test_fail_src("source/syntax/push_ref.dyon");
 }
 
 #[test]


### PR DESCRIPTION
- Bumped to 0.24.2
- Added “syntax/push_ref.dyon”