### PR TITLE
Copy lifetimes to node

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.24.2"
+version = "0.24.3"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/src/lifetime/mod.rs
+++ b/src/lifetime/mod.rs
@@ -389,7 +389,7 @@ pub fn check(
         let name = node.name().expect("Expected name").clone();
         if let Some(ref alias) = node.alias {
             if let Some(&i) = use_lookup.aliases.get(alias).and_then(|map| map.get(&name)) {
-                prelude.list[i].lts.clone();
+                node.lts = prelude.list[i].lts.clone();
                 continue;
             } else {
                 return Err(node.source.wrap(


### PR DESCRIPTION
- Bumped to 0.24.3

Fixes a bug when calling an imported function with no lifetimes.