### PR TITLE
Fixed bug in lifetime checker for objects and arrays

### DIFF
--- a/source/syntax/lifetime_18.dyon
+++ b/source/syntax/lifetime_18.dyon
@@ -1,0 +1,7 @@
+fn main() {
+    a := {}
+    for i 2 {
+        a[str(0)] := {foo: i}
+    }
+    println(a)
+}

--- a/source/syntax/lifetime_19.dyon
+++ b/source/syntax/lifetime_19.dyon
@@ -1,9 +1,7 @@
 fn main() {
     a := [0]
     for i 2 {
-        a[0] := {foo: clone(i)}
+        a[0] := {foo: i}
     }
     println(a)
 }
-
-foo(a: 'return f64) = [a]

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -43,9 +43,6 @@ pub struct Node {
     pub op: Option<AssignOp>,
     /// Binary operators.
     pub binops: Vec<BinOp>,
-    /// Number of ids.
-    /// Used to determine declaration of locals.
-    pub ids: u32,
     /// The argument lifetime constraints, one for each argument to a function.
     /// Just using an empty vector for nodes that are not functions.
     pub lts: Vec<Lt>,
@@ -57,6 +54,7 @@ impl Node {
         else { Some(&self.names[0]) }
     }
 
+    #[allow(dead_code)]
     pub fn print(&self, nodes: &[Node], indent: u32) {
         for _ in 0..indent { print!(" ") }
         println!("kind: {:?}, name: {:?}, type: {:?}, decl: {:?} {{",
@@ -338,7 +336,6 @@ pub fn convert_meta_data(
                     declaration: None,
                     op: None,
                     binops: vec![],
-                    ids: 0,
                     lts: vec![]
                 });
             }
@@ -384,10 +381,6 @@ pub fn convert_meta_data(
                     "lifetime" => {
                         let i = *parents.last().unwrap();
                         nodes[i].lifetime = Some(val.clone());
-                    }
-                    "id" => {
-                        let i = *parents.last().unwrap();
-                        nodes[i].ids += 1;
                     }
                     "text" => {
                         let i = *parents.last().unwrap();

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -67,6 +67,8 @@ fn test_syntax() {
     test_src("source/syntax/lifetime_15.dyon");
     test_fail_src("source/syntax/lifetime_16.dyon");
     test_src("source/syntax/lifetime_17.dyon");
+    test_fail_src("source/syntax/lifetime_18.dyon");
+    test_fail_src("source/syntax/lifetime_19.dyon");
     test_src("source/syntax/insert.dyon");
     test_src("source/syntax/named_call.dyon");
     test_src("source/syntax/max_min.dyon");


### PR DESCRIPTION
- Added test “lifetime_18”
- Added test “lifetime_19”
- Made `node` module not visible outside crate
- Removed `Node::ids` since it is replaced by `.item_ids`