### PR TITLE
Fixed bug in lifetime checker

### DIFF
--- a/source/syntax/lifetime_20.dyon
+++ b/source/syntax/lifetime_20.dyon
@@ -1,0 +1,6 @@
+fn main() {
+    i := 0
+    _ := foo(clone(i))
+}
+
+foo(a: 'return f64) = [a]

--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,9 +1,11 @@
 fn main() {
-    a := [0]
-    for i 2 {
-        a[0] := {foo: clone(i)}
+    b := [0]
+    a := [0, 0]
+    for i {
+        a[i] := foo(b)
     }
+    a[0][0][0] = 2
     println(a)
 }
 
-foo(a: 'return f64) = [a]
+foo(a: 'return [f64]) = [a]

--- a/src/lifetime/mod.rs
+++ b/src/lifetime/mod.rs
@@ -640,7 +640,14 @@ pub fn check(
             // Item is some levels down inside arg/add/expr/mul/val
             loop {
                 let node: &Node = &nodes[n];
-                if node.kind == Kind::Item { break; }
+                match node.kind {
+                    Kind::Item => break,
+                    Kind::Call => {
+                        can_be_item = false;
+                        break;
+                    }
+                    _ => {}
+                }
                 if node.children.len() == 0 {
                     can_be_item = false;
                     break;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -69,6 +69,7 @@ fn test_syntax() {
     test_src("source/syntax/lifetime_17.dyon");
     test_fail_src("source/syntax/lifetime_18.dyon");
     test_fail_src("source/syntax/lifetime_19.dyon");
+    test_fail_src("source/syntax/lifetime_20.dyon");
     test_src("source/syntax/insert.dyon");
     test_src("source/syntax/named_call.dyon");
     test_src("source/syntax/max_min.dyon");


### PR DESCRIPTION
Fixed bug in lifetime checker when calling a function that requires
reference to variable.

- Added test “lifetime_20”