### PR TITLE
Add the 'file' feature to allow turning off file access intrinsics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default-features = false
 optional = true
 
 [features]
-default = ["debug_resolve", "http"]
+default = ["debug_resolve", "http", "file"]
 debug_resolve = []
 http = ["reqwest"]
+file = []

--- a/src/intrinsics/data.rs
+++ b/src/intrinsics/data.rs
@@ -13,11 +13,17 @@ use Variable;
 type Strings = HashSet<Arc<String>>;
 
 /// Loads data from a file.
+#[cfg(feature = "file")]
 pub fn load_file(file: &str) -> Result<Variable, String> {
     let mut data_file = try!(File::open(file).map_err(|err| io_error("open", file, &err)));
     let mut d = String::new();
     try!(data_file.read_to_string(&mut d).map_err(|err| io_error("read", file, &err)));
     load_data(&d)
+}
+
+#[cfg(not(feature = "file"))]
+pub fn load_file(_: &str) -> Result<Variable, String> {
+    Err(super::FILE_SUPPORT_DISABLED.into())
 }
 
 /// Loads data from text.

--- a/src/intrinsics/meta.rs
+++ b/src/intrinsics/meta.rs
@@ -11,9 +11,6 @@ use super::io::io_error;
 
 use Variable;
 
-#[cfg(not(feature = "http"))]
-const HTTP_SUPPORT_DISABLED: &'static str = "Http support is disabled";
-
 pub fn parse_syntax_data(rules: &Syntax, file: &str, d: &str) -> Result<Vec<Variable>, String> {
     let mut tokens = vec![];
     try!(parse_errstr(&rules, &d, &mut tokens).map_err(|err|
@@ -65,6 +62,7 @@ fn load_metarules_data(meta: &str, s: &str, file: &str, d: &str) -> Result<Vec<V
 }
 
 /// Loads a file using a meta file as syntax.
+#[cfg(feature = "file")]
 pub fn load_meta_file(meta: &str, file: &str) -> Result<Vec<Variable>, String> {
     let mut syntax_file = try!(File::open(meta).map_err(|err| io_error("open", meta, &err)));
     let mut s = String::new();
@@ -73,6 +71,11 @@ pub fn load_meta_file(meta: &str, file: &str) -> Result<Vec<Variable>, String> {
     let mut d = String::new();
     try!(data_file.read_to_string(&mut d).map_err(|err| io_error("read", file, &err)));
     load_metarules_data(meta, &s, file, &d)
+}
+
+#[cfg(not(feature = "file"))]
+pub fn load_meta_file(_: &str, _: &str) -> Result<Vec<Variable>, String> {
+    Err(super::FILE_SUPPORT_DISABLED.into())
 }
 
 /// Loads a text file from url.
@@ -104,7 +107,7 @@ pub fn load_text_file_from_url(url: &str) -> Result<String, String> {
 
 #[cfg(not(feature = "http"))]
 pub fn load_text_file_from_url(_url: &str) -> Result<String, String> {
-    Err(HTTP_SUPPORT_DISABLED.into())
+    Err(super::HTTP_SUPPORT_DISABLED.into())
 }
 
 /// Loads an url using a meta file as syntax.
@@ -119,7 +122,7 @@ pub fn load_meta_url(meta: &str, url: &str) -> Result<Vec<Variable>, String> {
 
 #[cfg(not(feature = "http"))]
 pub fn load_meta_url(_meta: &str, _url: &str) -> Result<Vec<Variable>, String> {
-    Err(HTTP_SUPPORT_DISABLED.into())
+    Err(super::HTTP_SUPPORT_DISABLED.into())
 }
 
 // Downloads a file from url.
@@ -155,7 +158,7 @@ pub fn download_url_to_file(url: &str, file: &str) -> Result<String, String> {
 
 #[cfg(not(feature = "http"))]
 pub fn download_url_to_file(_url: &str, _file: &str) -> Result<String, String> {
-    Err(HTTP_SUPPORT_DISABLED.into())
+    Err(super::HTTP_SUPPORT_DISABLED.into())
 }
 
 pub fn json_from_meta_data(data: &Vec<Variable>) -> Result<String, io::Error> {

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -20,6 +20,12 @@ mod data;
 mod lifetimechk;
 mod functions;
 
+#[cfg(not(feature = "http"))]
+const HTTP_SUPPORT_DISABLED: &'static str = "Http support is disabled";
+
+#[cfg(not(feature = "file"))]
+const FILE_SUPPORT_DISABLED: &'static str = "File support is disabled";
+
 const X: usize = 0;
 const Y: usize = 1;
 const Z: usize = 2;
@@ -2145,6 +2151,7 @@ fn download__url_file(
     })))
 }
 
+#[cfg(feature = "file")]
 fn save__string_file(
     rt: &mut Runtime,
     call: &ast::Call,
@@ -2184,6 +2191,16 @@ fn save__string_file(
     })))
 }
 
+#[cfg(not(feature = "file"))]
+fn save__string_file(
+    _: &mut Runtime,
+    _: &ast::Call,
+    _: &Arc<Module>,
+) -> Result<Option<Variable>, String> {
+    Err(FILE_SUPPORT_DISABLED.into())
+}
+
+#[cfg(feature = "file")]
 fn load_string__file(
     rt: &mut Runtime,
     call: &ast::Call,
@@ -2220,6 +2237,15 @@ fn load_string__file(
             trace: vec![]
         }))
     })))
+}
+
+#[cfg(not(feature = "file"))]
+fn load_string__file(
+    _: &mut Runtime,
+    _: &ast::Call,
+    _: &Arc<Module>,
+) -> Result<Option<Variable>, String> {
+    Err(FILE_SUPPORT_DISABLED.into())
 }
 
 fn load_string__url(
@@ -2308,6 +2334,7 @@ fn load_data__file(
     Ok(Some(Variable::Result(res)))
 }
 
+#[cfg(feature = "file")]
 fn save__data_file(
     rt: &mut Runtime,
     call: &ast::Call,
@@ -2346,6 +2373,15 @@ fn save__data_file(
         }
     };
     Ok(Some(Variable::Result(res)))
+}
+
+#[cfg(not(feature = "file"))]
+fn save__data_file(
+    _: &mut Runtime,
+    _: &ast::Call,
+    _: &Arc<Module>,
+) -> Result<Option<Variable>, String> {
+    Err(FILE_SUPPORT_DISABLED.into())
 }
 
 fn json_from_meta_data(


### PR DESCRIPTION
In some environments, having built-in functions that access the filesystem is undesirable. Allow users to turn them off with a Cargo feature flag.

Hopefully I didn't accidentally miss any functions :D