### PR TITLE
Replace AST `Text`, `Number`, `Bool` with variable literals

### DIFF
--- a/src/ast/infer_len.rs
+++ b/src/ast/infer_len.rs
@@ -62,7 +62,6 @@ fn infer_expr(
             let right = infer_expr(&assign_expr.right, name, decls);
             if right.is_some() { return right; }
         }
-        Number(_) => {}
         Object(ref obj) => {
             for &(_, ref v) in &obj.key_values {
                 let res = infer_expr(v, name, decls);

--- a/src/ast/infer_len.rs
+++ b/src/ast/infer_len.rs
@@ -106,7 +106,6 @@ fn infer_expr(
                 if res.is_some() { return res; }
             }
         }
-        Bool(_) => {}
         For(ref for_expr) => {
             // TODO: Declaring counter with same name probably leads to a bug.
             let res = infer_expr(&for_expr.init, name, decls);

--- a/src/ast/infer_len.rs
+++ b/src/ast/infer_len.rs
@@ -99,7 +99,6 @@ fn infer_expr(
             let res = infer_call(call, name, decls);
             if res.is_some() { return res; }
         }
-        Text(_) => {}
         Vec4(ref vec4_expr) => {
             for expr in &vec4_expr.args {
                 let res = infer_expr(expr, name, decls);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -829,7 +829,6 @@ pub enum Expression {
     Item(Item),
     BinOp(Box<BinOpExpression>),
     Assign(Box<Assign>),
-    Text(Text),
     Vec4(Vec4),
     For(Box<For>),
     ForN(Box<ForN>),
@@ -938,10 +937,10 @@ impl Expression {
                 result = Some(Expression::Norm(Box::new(val)));
             } else if let Ok((range, val)) = convert.meta_string("text") {
                 convert.update(range);
-                result = Some(Expression::Text(Text {
-                    text: val,
-                    source_range: convert.source(start).unwrap(),
-                }));
+                result = Some(Expression::Variable(
+                    convert.source(start).unwrap(),
+                    Variable::Text(val)
+                ));
             } else if let Ok((range, val)) = convert.meta_f64("num") {
                 convert.update(range);
                 result = Some(Expression::Variable(
@@ -1108,7 +1107,6 @@ impl Expression {
             Item(ref it) => it.source_range,
             BinOp(ref binop) => binop.source_range,
             Assign(ref assign) => assign.source_range,
-            Text(ref text) => text.source_range,
             Vec4(ref vec4) => vec4.source_range,
             For(ref for_expr) => for_expr.source_range,
             ForN(ref for_n_expr) => for_n_expr.source_range,
@@ -1176,7 +1174,6 @@ impl Expression {
                 binop.resolve_locals(relative, stack, closure_stack, module, use_lookup),
             Assign(ref assign) =>
                 assign.resolve_locals(relative, stack, closure_stack, module, use_lookup),
-            Text(_) => {}
             Vec4(ref vec4) =>
                 vec4.resolve_locals(relative, stack, closure_stack, module, use_lookup),
             For(ref for_expr) =>
@@ -2998,12 +2995,6 @@ impl Sw {
             source_range: convert.source(start).unwrap(),
         }))
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct Text {
-    pub text: Arc<String>,
-    pub source_range: Range,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -831,7 +831,6 @@ pub enum Expression {
     Assign(Box<Assign>),
     Text(Text),
     Vec4(Vec4),
-    Bool(Bool),
     For(Box<For>),
     ForN(Box<ForN>),
     Sum(Box<ForN>),
@@ -959,10 +958,9 @@ impl Expression {
                 result = Some(val.to_expression());
             } else if let Ok((range, val)) = convert.meta_bool("bool") {
                 convert.update(range);
-                result = Some(Expression::Bool(Bool {
-                    val: val,
-                    source_range: convert.source(start).unwrap(),
-                }));
+                result = Some(Expression::Variable(
+                    convert.source(start).unwrap(), Variable::bool(val)
+                ));
             } else if let Ok((range, val)) = convert.meta_string("color") {
                 use read_color;
 
@@ -1112,7 +1110,6 @@ impl Expression {
             Assign(ref assign) => assign.source_range,
             Text(ref text) => text.source_range,
             Vec4(ref vec4) => vec4.source_range,
-            Bool(ref b) => b.source_range,
             For(ref for_expr) => for_expr.source_range,
             ForN(ref for_n_expr) => for_n_expr.source_range,
             Sum(ref for_n_expr) => for_n_expr.source_range,
@@ -1182,7 +1179,6 @@ impl Expression {
             Text(_) => {}
             Vec4(ref vec4) =>
                 vec4.resolve_locals(relative, stack, closure_stack, module, use_lookup),
-            Bool(_) => {}
             For(ref for_expr) =>
                 for_expr.resolve_locals(relative, stack, closure_stack, module, use_lookup),
             ForN(ref for_n_expr) =>
@@ -3011,12 +3007,6 @@ pub struct Text {
 }
 
 #[derive(Debug, Clone)]
-pub struct Bool {
-    pub val: bool,
-    pub source_range: Range,
-}
-
-#[derive(Debug, Clone)]
 pub struct For {
     pub init: Expression,
     pub cond: Expression,
@@ -3315,10 +3305,7 @@ impl Loop {
                 expressions: vec![],
                 source_range: source_range,
             }),
-            cond: Expression::Bool(Bool {
-                val: true,
-                source_range: source_range,
-            }),
+            cond: Expression::Variable(source_range, Variable::bool(true)),
             source_range: source_range,
         }))
     }

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use Variable;
 use super::{
     Array,
     ArrayFill,
@@ -19,7 +20,6 @@ use super::{
     Link,
     Object,
     Norm,
-    Number,
     Swizzle,
     UnOpExpression,
     Vec4,
@@ -44,7 +44,6 @@ pub fn number(expr: &Expression, name: &Arc<String>, val: f64) -> Expression {
                 source_range: link_expr.source_range,
             })
         }
-        E::Number(_) => expr.clone(),
         E::BinOp(ref bin_op_expr) => {
             E::BinOp(Box::new(BinOpExpression {
                 op: bin_op_expr.op,
@@ -55,10 +54,7 @@ pub fn number(expr: &Expression, name: &Arc<String>, val: f64) -> Expression {
         }
         E::Item(ref item) => {
             if &item.name == name {
-                E::Number(Number {
-                    num: val,
-                    source_range: item.source_range,
-                })
+                E::Variable(item.source_range, Variable::f64(val))
             } else {
                 let mut new_ids: Vec<Id> = vec![];
                 for id in &item.ids {

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -141,7 +141,6 @@ pub fn number(expr: &Expression, name: &Arc<String>, val: f64) -> Expression {
                 source_range: vec4_expr.source_range,
             })
         }
-        E::Bool(_) => expr.clone(),
         E::For(ref for_expr) => {
             let mut init: Option<Expression> = None;
             if let Expression::Assign(ref assign_expr) = for_expr.init {

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -130,7 +130,6 @@ pub fn number(expr: &Expression, name: &Arc<String>, val: f64) -> Expression {
                 source_range: go.source_range,
             }))
         }
-        E::Text(_) => expr.clone(),
         E::Vec4(ref vec4_expr) => {
             let mut new_args: Vec<Expression> = vec![];
             for arg in &vec4_expr.args {

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -72,7 +72,6 @@ pub fn grab_expr(
                 source_range: binop_expr.source_range,
             }))), Flow::Continue))
         }
-        &E::Number(_) |
         &E::Bool(_) |
         &E::Text(_) |
         &E::ReturnVoid(_) |

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -72,7 +72,6 @@ pub fn grab_expr(
                 source_range: binop_expr.source_range,
             }))), Flow::Continue))
         }
-        &E::Bool(_) |
         &E::Text(_) |
         &E::ReturnVoid(_) |
         &E::Break(_) |

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -72,7 +72,6 @@ pub fn grab_expr(
                 source_range: binop_expr.source_range,
             }))), Flow::Continue))
         }
-        &E::Text(_) |
         &E::ReturnVoid(_) |
         &E::Break(_) |
         &E::Continue(_) |

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -374,7 +374,6 @@ impl Runtime {
             Assign(ref assign) => self.assign(assign.op, &assign.left, &assign.right, module),
             Vec4(ref vec4) => self.vec4(vec4, side, module),
             Text(ref text) => Ok((Some(::Variable::Text(text.text.clone())), Flow::Continue)),
-            Bool(ref b) => Ok((Some(::Variable::bool(b.val)), Flow::Continue)),
             For(ref for_expr) => self.for_expr(for_expr, module),
             ForN(ref for_n_expr) => self.for_n_expr(for_n_expr, module),
             Sum(ref for_n_expr) => self.sum_n_expr(for_n_expr, module),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -373,7 +373,6 @@ impl Runtime {
             BinOp(ref binop) => self.binop(binop, side, module),
             Assign(ref assign) => self.assign(assign.op, &assign.left, &assign.right, module),
             Vec4(ref vec4) => self.vec4(vec4, side, module),
-            Text(ref text) => Ok((Some(::Variable::Text(text.text.clone())), Flow::Continue)),
             For(ref for_expr) => self.for_expr(for_expr, module),
             ForN(ref for_n_expr) => self.for_n_expr(for_n_expr, module),
             Sum(ref for_n_expr) => self.sum_n_expr(for_n_expr, module),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -372,7 +372,6 @@ impl Runtime {
             UnOp(ref unop) => self.unop(unop, side, module),
             BinOp(ref binop) => self.binop(binop, side, module),
             Assign(ref assign) => self.assign(assign.op, &assign.left, &assign.right, module),
-            Number(ref num) => Ok((Some(::Variable::f64(num.num)), Flow::Continue)),
             Vec4(ref vec4) => self.vec4(vec4, side, module),
             Text(ref text) => Ok((Some(::Variable::Text(text.text.clone())), Flow::Continue)),
             Bool(ref b) => Ok((Some(::Variable::bool(b.val)), Flow::Continue)),

--- a/src/write.rs
+++ b/src/write.rs
@@ -189,7 +189,6 @@ pub fn write_expr<W: io::Write>(
     match expr {
         &E::BinOp(ref binop) => try!(write_binop(w, rt, binop, tabs)),
         &E::Item(ref item) => try!(write_item(w, rt, item, tabs)),
-        &E::Number(ref number) => try!(write!(w, "{}", number.num)),
         &E::Text(ref text) => try!(json::write_string(w, &text.text)),
         &E::Bool(ref b) => try!(write!(w, "{}", b.val)),
         &E::Variable(_, ref var) => try!(write_variable(w, rt, var, EscapeString::Json, tabs)),
@@ -551,8 +550,8 @@ pub fn write_vec4<W: io::Write>(
 ) -> Result<(), io::Error> {
     let mut n = vec4.args.len();
     for expr in vec4.args.iter().rev() {
-        if let &ast::Expression::Number(ref num) = expr {
-            if num.num == 0.0 {
+        if let &ast::Expression::Variable(_, Variable::F64(num, _)) = expr {
+            if num == 0.0 {
                 n -= 1;
                 continue;
             }

--- a/src/write.rs
+++ b/src/write.rs
@@ -190,7 +190,6 @@ pub fn write_expr<W: io::Write>(
         &E::BinOp(ref binop) => try!(write_binop(w, rt, binop, tabs)),
         &E::Item(ref item) => try!(write_item(w, rt, item, tabs)),
         &E::Text(ref text) => try!(json::write_string(w, &text.text)),
-        &E::Bool(ref b) => try!(write!(w, "{}", b.val)),
         &E::Variable(_, ref var) => try!(write_variable(w, rt, var, EscapeString::Json, tabs)),
         &E::Link(ref link) => try!(write_link(w, rt, link, tabs)),
         &E::Object(ref obj) => try!(write_obj(w, rt, obj, tabs)),
@@ -608,8 +607,8 @@ pub fn write_for<W: io::Write>(
 ) -> Result<(), io::Error> {
     if let ast::Expression::Block(ref b) = f.init {
         if b.expressions.len() == 0 {
-            if let ast::Expression::Bool(ref b) = f.cond {
-                if b.val {
+            if let ast::Expression::Variable(_, Variable::Bool(b, _)) = f.cond {
+                if b {
                     if let ast::Expression::Block(ref b) = f.step {
                         if b.expressions.len() == 0 {
                             try!(write!(w, "loop "));

--- a/src/write.rs
+++ b/src/write.rs
@@ -189,7 +189,6 @@ pub fn write_expr<W: io::Write>(
     match expr {
         &E::BinOp(ref binop) => try!(write_binop(w, rt, binop, tabs)),
         &E::Item(ref item) => try!(write_item(w, rt, item, tabs)),
-        &E::Text(ref text) => try!(json::write_string(w, &text.text)),
         &E::Variable(_, ref var) => try!(write_variable(w, rt, var, EscapeString::Json, tabs)),
         &E::Link(ref link) => try!(write_link(w, rt, link, tabs)),
         &E::Object(ref obj) => try!(write_obj(w, rt, obj, tabs)),


### PR DESCRIPTION
There is no need to have separate expression nodes for `Text`, `Number` and `Bool` in addition to variable literals.