### PR TITLE
Added support for namespaces in external functions

### DIFF
--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,7 +1,11 @@
-fn log(a: f64) {}
+ns loader
 
 fn main() {
-    log := in log
-    for i 3 {log(i)}
-    println(sum x in log {x[0]})
+    math := unwrap(load("source/namespace/math.dyon"))
+    graphics := unwrap(load("source/namespace/graphics.dyon"))
+    main := unwrap(load(
+        source: "source/namespace/main.dyon",
+        imports: [math, graphics]
+    ))
+    call(main, "main", [])
 }

--- a/src/lifetime/mod.rs
+++ b/src/lifetime/mod.rs
@@ -412,7 +412,10 @@ pub fn check(
         let node = &mut nodes[c];
         let name = node.name().expect("Expected name").clone();
         if let Some(ref alias) = node.alias {
-            if let Some(&i) = use_lookup.aliases.get(alias).and_then(|map| map.get(&name)) {
+            use ast::FnAlias;
+
+            // External functions are treated as loaded in prelude.
+            if let Some(&FnAlias::Loaded(i)) = use_lookup.aliases.get(alias).and_then(|map| map.get(&name)) {
                 node.lts = prelude.list[i].lts.clone();
                 continue;
             } else {
@@ -456,7 +459,10 @@ pub fn check(
         let node = &mut nodes[c];
         let name = node.name().expect("Expected name").clone();
         if let Some(ref alias) = node.alias {
-            if let Some(&i) = use_lookup.aliases.get(alias).and_then(|map| map.get(&name)) {
+            use ast::FnAlias;
+
+            // External functions are treated as loaded in prelude.
+            if let Some(&FnAlias::Loaded(i)) = use_lookup.aliases.get(alias).and_then(|map| map.get(&name)) {
                 node.lts = prelude.list[i].lts.clone();
                 continue;
             } else {

--- a/src/lifetime/typecheck.rs
+++ b/src/lifetime/typecheck.rs
@@ -144,7 +144,10 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude, use_lookup: &UseLookup) -> 
                                     (&None, _) | (_, &None) => {}
                                 }
                             } else if let Some(ref alias) = nodes[parent].alias {
-                                if let Some(&f) = use_lookup.aliases.get(alias)
+                                use ast::FnAlias;
+
+                                // External functions are treated as loaded in prelude.
+                                if let Some(&FnAlias::Loaded(f)) = use_lookup.aliases.get(alias)
                                 .and_then(|map| map.get(nodes[parent].name().unwrap())) {
                                     let f = &prelude.list[f];
                                     if let Some(ref ty) = expr_type {
@@ -180,7 +183,10 @@ pub fn run(nodes: &mut Vec<Node>, prelude: &Prelude, use_lookup: &UseLookup) -> 
                             this_ty = Some(ty.clone());
                         }
                     } else if let Some(ref alias) = nodes[i].alias {
-                        if let Some(&f) = use_lookup.aliases.get(alias)
+                        use ast::FnAlias;
+
+                        // External functions are treated as loaded in prelude.
+                        if let Some(&FnAlias::Loaded(f)) = use_lookup.aliases.get(alias)
                         .and_then(|map| map.get(nodes[i].name().unwrap())) {
                             this_ty = Some(prelude.list[f].ret.clone());
                         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -95,7 +95,7 @@ impl Prelude {
         let mut prelude = Prelude::new();
         intrinsics::standard(&mut prelude);
         for f in &*module.ext_prelude {
-            prelude.insert(Arc::new(vec![]), f.name.clone(), f.p.clone());
+            prelude.insert(f.namespace.clone(), f.name.clone(), f.p.clone());
         }
         for f in &module.functions {
             prelude.insert(f.namespace.clone(), f.name.clone(), Dfn::new(f));

--- a/string/source/test.dyon
+++ b/string/source/test.dyon
@@ -1,3 +1,5 @@
+use string::{regex_matches as matches__regex_pat} as string
+
 fn main() {
     text := "Hello\nHow are you?"
     println(text)
@@ -11,5 +13,5 @@ fn main() {
     // println(to_ascii_lowercase(text))
     // println(to_ascii_uppercase(text))
     reg := unwrap(regex("^\\d{4}-\\d{2}-\\d{2}$"))
-    println(regex_matches(reg, "2000-10-12"))
+    println(string::matches(regex: reg, pat: "2000-10-12"))
 }

--- a/string/src/lib.dyon
+++ b/string/src/lib.dyon
@@ -1,3 +1,5 @@
+ns string
+
 /// Splits text into lines.
 fn lines(text: str) -> [str] { ... }
 

--- a/string/src/lib.rs
+++ b/string/src/lib.rs
@@ -8,6 +8,7 @@ use dyon::{Dfn, Lt, Type, Module, Variable, RustObject};
 
 /// Adds string functions to module.
 pub fn add_functions(module: &mut Module) {
+    module.ns("string");
     module.add(Arc::new("lines".into()), lines, Dfn {
         lts: vec![Lt::Default],
         tys: vec![Type::Text],


### PR DESCRIPTION
This add support for namespaces in external functions:

```rust
pub fn add_functions(module: &mut Module) {
    module.ns("string");
    module.add(Arc::new("lines".into()), lines, Dfn {
        lts: vec![Lt::Default],
        tys: vec![Type::Text],
     ...
```

Closes https://github.com/PistonDevelopers/dyon/issues/388