### PR TITLE
README: Add link to vscode-language-dyon extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ dyonrun <file.dyon>
 
 ### Editor-plugins
 
-[Dyon for the Atom Editor](https://github.com/PistonDevelopers/atom-language-dyon)  
-[Dyon for the Vim Editor](https://github.com/thyrgle/vim-dyon)  
+[Dyon for the Atom Editor](https://github.com/PistonDevelopers/atom-language-dyon)
+[Dyon for the Vim Editor](https://github.com/thyrgle/vim-dyon)
+[Dyon for Visual Studio Code](https://github.com/martinlindhe/vscode-language-dyon)
 
 ![coding](./images/code.png)
 


### PR DESCRIPTION
I created a vscode extension for dyon syntax highlighting based on your Atom extension.

Published at
https://github.com/martinlindhe/vscode-language-dyon
https://marketplace.visualstudio.com/items?itemName=martinlindhe.vscode-language-dyon

This PR adds a link to the extension