### PR TITLE
Make `norm` external function

### DIFF
--- a/source/test.dyon
+++ b/source/test.dyon
@@ -1,6 +1,6 @@
+norm(x: f64) = x+1
+
 fn main() {
-    a := try {
-        println("hi")
-    }
-    println(a)
+    a := \(x: f64) = |x|
+    println(\a(2))
 }

--- a/source/typechk/norm.dyon
+++ b/source/typechk/norm.dyon
@@ -1,0 +1,5 @@
+norm(x: f64) = sin(x)
+
+fn main() {
+    println(|(2, 3)|)
+}

--- a/src/ast/infer_len.rs
+++ b/src/ast/infer_len.rs
@@ -214,10 +214,6 @@ fn infer_expr(
             let right = infer_expr(&cmp_expr.right, name, decls);
             if right.is_some() { return right; }
         }
-        Norm(ref norm) => {
-            let res = infer_expr(&norm.expr, name, decls);
-            if res.is_some() { return res; }
-        }
         UnOp(ref unop_expr) => {
             let res = infer_expr(&unop_expr.expr, name, decls);
             if res.is_some() { return res; }

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -20,7 +20,6 @@ use super::{
     Item,
     Link,
     Object,
-    Norm,
     Swizzle,
     UnOpExpression,
     Vec4,
@@ -326,12 +325,6 @@ pub fn number(expr: &Expression, name: &Arc<String>, val: f64) -> Expression {
                 left: number(&cmp_expr.left, name, val),
                 right: number(&cmp_expr.right, name, val),
                 source_range: cmp_expr.source_range,
-            }))
-        }
-        E::Norm(ref norm) => {
-            E::Norm(Box::new(Norm {
-                expr: number(&norm.expr, name, val),
-                source_range: norm.source_range,
             }))
         }
         E::UnOp(ref unop_expr) => {

--- a/src/dyon_std/mod.rs
+++ b/src/dyon_std/mod.rs
@@ -18,6 +18,7 @@ dyon_fn!{fn x(v: Vec4) -> f64 {f64::from(v.0[0])}}
 dyon_fn!{fn y(v: Vec4) -> f64 {f64::from(v.0[1])}}
 dyon_fn!{fn z(v: Vec4) -> f64 {f64::from(v.0[2])}}
 dyon_fn!{fn w(v: Vec4) -> f64 {f64::from(v.0[3])}}
+dyon_fn!{fn norm(v: Vec4) -> f32 {vecmath::vec4_len(v.0)}}
 
 pub(crate) fn s(rt: &mut Runtime) -> Result<(), String> {
     let ind: f64 = rt.pop().expect(TINVOTS);

--- a/src/grab.rs
+++ b/src/grab.rs
@@ -310,15 +310,6 @@ pub fn grab_expr(
                 source_range: unop.source_range,
             }))), Flow::Continue))
         }
-        E::Norm(ref norm) => {
-            Ok((Grabbed::Expression(E::Norm(Box::new(ast::Norm {
-                expr: match grab_expr(level, rt, &norm.expr, side) {
-                    Ok((Grabbed::Expression(x), Flow::Continue)) => x,
-                    x => return x,
-                },
-                source_range: norm.source_range,
-            }))), Flow::Continue))
-        }
         E::Vec4(ref vec4) => {
             Ok((Grabbed::Expression(E::Vec4(Box::new(ast::Vec4 {
                 args: {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,7 @@ impl Module {
         m.add_str("y", y, Dfn::nl(vec![Vec4], F64));
         m.add_str("z", z, Dfn::nl(vec![Vec4], F64));
         m.add_str("w", w, Dfn::nl(vec![Vec4], F64));
+        m.add_str("norm", norm, Dfn::nl(vec![Vec4], F64));
         m.add_str("det", det, Dfn::nl(vec![Mat4], F64));
         m.add_str("inv", inv, Dfn::nl(vec![Mat4], Mat4));
         m.add_str("mov", mov, Dfn::nl(vec![Vec4], Mat4));

--- a/src/lifetime/mod.rs
+++ b/src/lifetime/mod.rs
@@ -28,6 +28,21 @@ pub fn check(
     let mut nodes: Vec<Node> = vec![];
     convert_meta_data(&mut nodes, data)?;
 
+    // Rewrite graph for syntax sugar that corresponds to function calls.
+    for i in 0..nodes.len() {
+        match nodes[i].kind {
+            Kind::Norm => {
+                if nodes[i].children.len() == 1 {
+                    nodes[i].kind = Kind::Call;
+                    nodes[i].names.push(Arc::new("norm".into()));
+                    let ch = nodes[i].children[0];
+                    nodes[ch].kind = Kind::CallArg;
+                }
+            }
+            _ => {}
+        }
+    }
+
     // Add mutability information to function names.
     for i in 0..nodes.len() {
         match nodes[i].kind {

--- a/src/lifetime/node.rs
+++ b/src/lifetime/node.rs
@@ -323,7 +323,6 @@ pub fn convert_meta_data(
                     Kind::Object => Some(Type::object()),
                     Kind::Sift | Kind::SiftIn => Some(Type::array()),
                     Kind::Sum | Kind::SumIn | Kind::Prod | Kind::ProdIn => Some(Type::F64),
-                    Kind::Norm => Some(Type::F64),
                     Kind::Swizzle => Some(Type::F64),
                     Kind::Link | Kind::LinkFor => Some(Type::Link),
                     Kind::Any | Kind::AnyIn | Kind::All | Kind::AllIn =>

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -512,7 +512,6 @@ impl Runtime {
                 self.call_internal(call, loader)
             }
             Item(ref item) => self.item(item, side),
-            Norm(ref norm) => self.norm(norm, side),
             UnOp(ref unop) => self.unop(unop, side),
             BinOp(ref binop) => self.binop(binop, side),
             Assign(ref assign) => self.assign(assign.op, &assign.left, &assign.right),
@@ -2482,20 +2481,6 @@ impl Runtime {
             [x[2], y[2], z[2], w[2]],
             [x[3], y[3], z[3], w[3]],
         ]))), Flow::Continue))
-    }
-    fn norm(&mut self, norm: &ast::Norm, side: Side) -> FlowResult {
-        let val = match self.expression(&norm.expr, side)? {
-            (Some(x), Flow::Continue) => x,
-            (x, Flow::Return) => return Ok((x, Flow::Return)),
-            _ => return self.err(norm.source_range, "Expected something from unary argument")
-        };
-        let v = match *self.resolve(&val) {
-            Variable::Vec4(b) => {
-                Variable::f64(f64::from(b[0] * b[0] + b[1] * b[1] + b[2] * b[2]).sqrt())
-            }
-            ref x => return self.err(norm.source_range, &self.expected(x, "vec4"))
-        };
-        Ok((Some(v), Flow::Continue))
     }
     fn unop(&mut self, unop: &ast::UnOpExpression, side: Side) -> FlowResult {
         let val = match self.expression(&unop.expr, side)? {

--- a/src/write.rs
+++ b/src/write.rs
@@ -202,7 +202,13 @@ fn write_expr<W: io::Write>(
         E::Object(ref obj) => write_obj(w, rt, obj, tabs)?,
         E::Array(ref arr) => write_arr(w, rt, arr, tabs)?,
         E::ArrayFill(ref arr_fill) => write_arr_fill(w, rt, arr_fill, tabs)?,
-        E::Call(ref call) => write_call(w, rt, call, tabs)?,
+        E::Call(ref call) => {
+            if &**call.name == "norm" && call.args.len() == 1 {
+                write_norm(w, rt, &call.args[0], tabs)?
+            } else {
+                write_call(w, rt, call, tabs)?
+            }
+        }
         E::Return(ref expr) => {
             write!(w, "return ")?;
             write_expr(w, rt, expr, tabs)?;
@@ -313,7 +319,6 @@ fn write_expr<W: io::Write>(
             write_for_in(w, rt, for_in, tabs)?;
         }
         E::If(ref if_expr) => write_if(w, rt, if_expr, tabs)?,
-        E::Norm(ref norm) => write_norm(w, rt, norm, tabs)?,
         E::UnOp(ref unop) => write_unop(w, rt, unop, tabs)?,
         E::Try(ref expr) => {
             write_expr(w, rt, expr, tabs)?;
@@ -329,6 +334,18 @@ fn write_expr<W: io::Write>(
         }
         // x => panic!("Unimplemented `{:#?}`", x),
     }
+    Ok(())
+}
+
+fn write_norm<W: io::Write>(
+    w: &mut W,
+    rt: &Runtime,
+    expr: &ast::Expression,
+    tabs: u32
+) -> Result<(), io::Error> {
+    write!(w, "|")?;
+    write_expr(w, rt, &expr, tabs)?;
+    write!(w, "|")?;
     Ok(())
 }
 
@@ -403,18 +420,6 @@ fn write_binop<W: io::Write>(
     if right_needs_parens {
         write!(w, ")")?;
     }
-    Ok(())
-}
-
-fn write_norm<W: io::Write>(
-    w: &mut W,
-    rt: &Runtime,
-    norm: &ast::Norm,
-    tabs: u32
-) -> Result<(), io::Error> {
-    write!(w, "|")?;
-    write_expr(w, rt, &norm.expr, tabs)?;
-    write!(w, "|")?;
     Ok(())
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -220,6 +220,7 @@ fn test_typechk() {
     test_fail_src("source/typechk/mat4_1.dyon");
     test_src("source/typechk/mat4_2.dyon");
     test_src("source/typechk/ind_arr.dyon");
+    test_fail_src("source/typechk/norm.dyon");
 }
 
 #[test]


### PR DESCRIPTION
See https://github.com/PistonDevelopers/dyon/issues/635

The `norm` function only takes `vec4`, so it can be made external without affecting type inference.

- Added “typechk/norm.dyon”