### PR TITLE
Gate threading behind cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ default-features = false
 optional = true
 
 [features]
-default = ["debug_resolve", "http", "file"]
+default = ["debug_resolve", "http", "file", "threading"]
 debug_resolve = []
 http = ["reqwest"]
 file = []
+threading = []

--- a/src/lifetime/kind.rs
+++ b/src/lifetime/kind.rs
@@ -192,7 +192,7 @@ impl Kind {
             "res" => Kind::Res,
             "ret_type" => Kind::RetType,
             "return_void" => Kind::ReturnVoid,
-            "go" => Kind::Go,
+            #[cfg(feature = "threading")] "go" => Kind::Go,
             "swizzle" => Kind::Swizzle,
             "sw0" => Kind::Sw0,
             "sw1" => Kind::Sw1,


### PR DESCRIPTION
Closes #658 

@bvssvni So I've tried to keep it 'simple' as this should simply disable parsing of the 'go' keyword, which is enough for my specific use-case. But it does not remove the threading dependency, which could be attached to this PR but is more involved (which I am not sure how it should look like)