### PR TITLE
Fixed bug in Rust object macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dyon"
-version = "0.45.0"
+version = "0.45.1"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 keywords = ["script", "scripting", "game", "language", "piston"]
 description = "A rusty dynamically typed scripting language"

--- a/interactive/Cargo.toml
+++ b/interactive/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://github.com/pistondevelopers/dyon/interactive"
 name = "dyon_interactive"
 
 [dependencies.dyon]
-version = "0.45.0"
+version = "0.45.1"
 path = ".."
 
 [dependencies]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -96,8 +96,8 @@ macro_rules! dyon_fn {
                     $b
                 }
 
-                dyon_fn_pop!(#& rt $rust_arg: $rust_t);
                 dyon_fn_pop!(rt $($arg: $t),+);
+                dyon_fn_pop!(#& rt $rust_arg: $rust_t);
                 Ok($crate::Variable::RustObject(Arc::new(Mutex::new(inner($rust_arg, $($arg),+)))))
             }
         }
@@ -110,8 +110,8 @@ macro_rules! dyon_fn {
                     $b
                 }
 
-                dyon_fn_pop!(#& rt $rust_arg: $rust_t);
                 dyon_fn_pop!(rt $($arg: $t),*);
+                dyon_fn_pop!(#& rt $rust_arg: $rust_t);
                 Ok($crate::embed::PushVariable::push_var(&inner($rust_arg, $($arg),*)))
             }
         }
@@ -124,8 +124,8 @@ macro_rules! dyon_fn {
                     $b
                 }
 
-                dyon_fn_pop!(# rt $rust_arg: $rust_t);
                 dyon_fn_pop!(rt $($arg: $t),+);
+                dyon_fn_pop!(# rt $rust_arg: $rust_t);
                 Ok($crate::embed::PushVariable::push_var(&inner($rust_arg, $($arg),+)))
             }
         }
@@ -191,8 +191,8 @@ macro_rules! dyon_fn {
                     $b
                 }
 
-                dyon_fn_pop!(#&mut rt $rust_arg: $rust_ty);
                 dyon_fn_pop!(rt $($arg: $t),*);
+                dyon_fn_pop!(#&mut rt $rust_arg: $rust_ty);
                 inner($rust_arg, $($arg),+);
                 Ok(())
             }
@@ -206,8 +206,8 @@ macro_rules! dyon_fn {
                     $b
                 }
 
-                dyon_fn_pop!(# rt $rust_arg: $rust_ty);
                 dyon_fn_pop!(rt $($arg: $t),*);
+                dyon_fn_pop!(# rt $rust_arg: $rust_ty);
                 inner($rust_arg, $($arg),+);
                 Ok(())
             }


### PR DESCRIPTION
- Bumped to 0.45.1

Arguments were popped in wrong order.