### PR TITLE
Added REPL

### DIFF
--- a/assets/repl/help.txt
+++ b/assets/repl/help.txt
@@ -1,0 +1,30 @@
+=== Dyon Help ===
+Dyon was started by Sven Nilsen in 2016.
+
+To calculate something, try e.g. `1 + 1`.
+
+To define a constant, use e.g. `a() = 3`.
+Use `a` with parenthesis, e.g. `a() + 2`.
+
+To write multiple lines use `\` and finish with two empty lines:
+
+    > \
+    fn run() {
+        println("hello world!")
+    }
+
+    > call "run"
+    "hello world!"
+
+Commands:
+
+- bye               Exit program
+- ``                Prints separator for readability
+- \                 Input multiple lines
+- ctx               Show context
+- clear             Clear context and starts new file
+- load "<file>"     Clear context and load Dyon file
+- save              Save context
+- save "<file>"     Save context to file
+- import "<file>"   Import Dyon module
+- call "<fun>"      Call function

--- a/assets/repl/help.txt
+++ b/assets/repl/help.txt
@@ -1,6 +1,8 @@
 === Dyon Help ===
 Dyon was started by Sven Nilsen in 2016.
 
+For tutorial, visit https://www.piston.rs/dyon-tutorial/
+
 To calculate something, try e.g. `1 + 1`.
 
 To define a constant, use e.g. `a() = 3`.

--- a/examples/dyon.rs
+++ b/examples/dyon.rs
@@ -1,0 +1,206 @@
+extern crate dyon;
+extern crate read_token;
+
+use std::io::Write;
+use std::sync::Arc;
+
+use dyon::{error, load, load_str, Module, Runtime};
+
+fn main() {
+    let mut file: Option<String> = None;
+    let mut imports: Vec<Module> = vec![];
+
+    let mut module = Module::new();
+    let mut ctx = String::new();
+
+    println!("=== Dyon 0.48 ===");
+    println!("Type `help` for more information.");
+    loop {
+        if let Some(x) = file.as_ref() {
+            print!("({}) ", x);
+        }
+        print!("> ");
+        let _ = std::io::stdout().flush();
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input).expect("Expected input");
+
+        let command = input.trim().to_string();
+
+        if command == "\\" {
+            input = String::new();
+            let mut empty_lines = 0;
+            loop {
+                let mut line = String::new();
+                std::io::stdin().read_line(&mut line).expect("Expected input");
+                if line.trim() == "" {
+                    empty_lines += 1;
+                    if empty_lines >= 2 {break}
+                } else {
+                    if empty_lines > 0 {input.push_str("\n")}
+                    empty_lines = 0;
+                    input.push_str(&line);
+                }
+            }
+        }
+
+        match &*command {
+            "bye" => break,
+            "ctx" => {
+                println!("{}", ctx);
+                continue;
+            }
+            "clear" => {
+                ctx = String::new();
+                module = Module::new();
+                file = None;
+                continue;
+            }
+            "help" => {
+                println!("{}", include_str!("../assets/repl/help.txt"));
+                continue;
+            }
+            "save" => {
+                if let Some(x) = file.as_ref() {
+                    if std::fs::write(x, &ctx).is_err() {
+                        println!("Saving failed.");
+                    }
+                } else {
+                    println!("Could not save.\nUse `save \"<file>\"`.");
+                }
+                continue;
+            }
+            _ if command.starts_with("save ") => {
+                let new_file = if let Some(x) = json_str(&command[5..]) {x}
+                               else {
+                                    println!("Saving failed.");
+                                    continue;
+                               };
+                if std::fs::write(&new_file, &ctx).is_err() {
+                    println!("Saving failed.");
+                    continue;
+                }
+                file = Some(new_file);
+                continue;
+            }
+            _ if command.starts_with("load ") => {
+                println!("Loading...");
+
+                let new_file = if let Some(x) = json_str(&command[5..]) {x}
+                           else {
+                                println!("Loading failed.");
+                                continue;
+                           };
+                println!("  {}", new_file);
+
+                ctx = match std::fs::read_to_string(&new_file) {
+                    Ok(x) => x,
+                    Err(_) => {
+                        println!("Could not load {}", new_file);
+                        continue;
+                    }
+                };
+                file = Some(new_file);
+                if reload(&ctx, &mut module, &imports) {
+                    continue;
+                }
+
+                println!("Done!");
+                continue;
+            }
+            _ if command.starts_with("import ") => {
+                println!("Importing...");
+
+                let file = if let Some(x) = json_str(&command[7..]) {x}
+                           else {
+                                println!("Import failed.");
+                                continue;
+                           };
+                println!("  {}", file);
+                let mut m = Module::new();
+                if error(load(&file, &mut m)) {
+                    continue;
+                }
+                imports.push(m);
+
+                if reload(&ctx, &mut module, &imports) {
+                    continue;
+                }
+
+                println!("Done!");
+                continue;
+            }
+            _ if command.starts_with("call ") => {
+                let f = if let Some(x) = json_str(&command[5..]) {x}
+                        else {
+                            println!("Could not call function.");
+                            continue;
+                        };
+                input = format!("{{\n{}()\nreturn\n}}\n", f);
+            }
+            "" => {
+                // Print separator for readability.
+                print!("\n------------------------------------<o=o");
+                println!("o=o>------------------------------------\n");
+                continue;
+            }
+            _ => {}
+        }
+
+        let mut sub_module = Module::new();
+        sub_module.import(&module);
+        let res = load_str("dyonrepl", Arc::new(input.clone()), &mut sub_module); 
+        if res.is_err() {
+            // Try evaluation expression.
+            let code = format!("fn main() {{println({})}}", input);
+            if error(run_str_with_module("dyonrepl", Arc::new(code), &module)) {
+                error(res);
+            }
+        } else {
+            println!("{}", input);
+
+            ctx.push_str(&input);
+            if reload(&ctx, &mut module, &imports) {
+                continue;
+            }
+        }
+    }
+}
+
+fn reload(ctx: &str, module: &mut Module, imports: &[Module]) -> bool {
+    let mut new_module = Module::new();
+    for m in imports {new_module.import(m)};
+    if !error(load_str("dyonrep", Arc::new(ctx.into()), &mut new_module)) {
+        *module = new_module;
+        false
+    } else {true}
+}
+
+fn run_str_with_module(
+    source: &str,
+    d: Arc<String>,
+    module: &Module,
+) -> Result<(), String> {
+    let mut m = Module::new();
+    m.import(module);
+    load_str(source, d, &mut m)?;
+    let mut runtime = Runtime::new();
+    runtime.run(&Arc::new(m))?;
+    Ok(())
+}
+
+// Parses a JSON string.
+fn json_str(txt: &str) -> Option<String> {
+    use read_token::ReadToken;
+    let r = ReadToken::new(txt, 0);
+    if let Some(range) = r.string() {
+        if let Ok(txt) = r.parse_string(range.length) {
+            Some(txt)
+        } else {
+            println!("ERROR:\nCould not parse string");
+            None
+        }
+    } else {
+        println!("ERROR:\nExpected string");
+        None
+    }
+}


### PR DESCRIPTION
See https://github.com/PistonDevelopers/dyon/issues/735

Example:

```text
=== Dyon 0.48 ===
Type `help` for more information.
> sum i 100 {i}
4950
```

### Comments about the design

Adds a new "dyon" example which can be installed using:

```text
cargo install --example dyon dyon
```

To run, type:

```text
dyon
```

I have previously been too much focused on thinking about REPLs where you declare variables and put them in the context. Dyon is designed to load modules without allocating memory. Instead of trying to change Dyon's design, I think the best solution is to build a REPL around the common use of Dyon.

One can use mathematical notation for functions to e.g. declare constants:

```text
a() = 3
```